### PR TITLE
Refactor and Cleaning

### DIFF
--- a/nix_flake/flake.nix
+++ b/nix_flake/flake.nix
@@ -30,6 +30,15 @@
               extensions = [ "rust-src" "clippy" "rustfmt" ];
             })
           ];
+
+          shellHook = ''
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
+              pkgs.wayland
+              pkgs.libxkbcommon
+              pkgs.mesa
+              pkgs.libGL
+            ]}:$LD_LIBRARY_PATH
+          '';
         };
       });
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,0 +1,16 @@
+pub enum AppAction {
+    SpawnWidget(WidgetType),
+    CloseTile(egui_tiles::TileId),
+}
+
+pub enum WidgetType {
+    ViewerTable,
+    ViewerList,
+    Bootloader,
+    Scope {
+        msg_id: u32,
+        msg_name: String,
+        signal_name: String,
+    },
+    LogParser,
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,6 +1,5 @@
 pub enum AppAction {
     SpawnWidget(WidgetType),
-    CloseTile(egui_tiles::TileId),
 }
 
 pub enum WidgetType {

--- a/src/app.rs
+++ b/src/app.rs
@@ -86,7 +86,7 @@ impl DAQApp {
             theme: theme_style,
             theme_selection,
             pixels_per_point: default_scale,
-            serial_ports: util::get_avaible_serial_ports(),
+            serial_ports: util::get_available_serial_ports(),
             parser: ParserInfo::new_maybe(settings.dbc_path),
             udp_port: settings.udp_port,
             can_messages: Vec::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{can, settings, shortcuts, theme, util, ui, widgets, workspace};
+use crate::{can, settings, shortcuts, theme, ui, util, widgets, workspace};
 use eframe::egui;
 
 const MIN_UI_SCALE: f32 = 0.4;

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,22 @@ use eframe::egui;
 const MIN_UI_SCALE: f32 = 0.4;
 const MAX_UI_SCALE: f32 = 5.0;
 
+pub struct ParserInfo {
+    pub dbc_path: std::path::PathBuf,
+    pub parser: can_decode::Parser,
+}
+
+impl ParserInfo {
+    pub fn new(dbc_path: std::path::PathBuf) -> Self {
+        let parser =
+            can_decode::Parser::from_dbc_file(&dbc_path).expect("Failed to parse DBC file");
+        Self { dbc_path, parser }
+    }
+    pub fn new_maybe(dbc_path: Option<std::path::PathBuf>) -> Option<Self> {
+        dbc_path.map(|path| Self::new(path))
+    }
+}
+
 pub struct DAQApp {
     pub is_sidebar_open: bool,
     pub tile_tree: egui_tiles::Tree<widgets::Widget>,
@@ -19,7 +35,7 @@ pub struct DAQApp {
     pub pixels_per_point: f32,
     pub selected_serial: Option<String>,
     pub serial_ports: Vec<serialport::SerialPortInfo>,
-    pub dbc_path: Option<std::path::PathBuf>,
+    pub parser: Option<ParserInfo>,
     pub connection_error: Option<String>,
     pub can_messages: Vec<can::can_messages::CanMessage>,
 }
@@ -27,7 +43,7 @@ pub struct DAQApp {
 impl DAQApp {
     pub fn save_settings(&self) {
         let settings = settings::Settings {
-            dbc_path: self.dbc_path.clone(),
+            dbc_path: self.parser.as_ref().map(|p| p.dbc_path.clone()),
             selected_serial: self.selected_serial.clone(),
             theme: self.theme_selection,
         };
@@ -47,7 +63,6 @@ impl DAQApp {
         let theme_style = theme_selection.get_style();
 
         let selected_serial = settings.selected_serial.clone();
-        let dbc_path = settings.dbc_path.clone();
         Self {
             is_sidebar_open: true,
             tile_tree: egui_tiles::Tree::empty("workspace_tree"),
@@ -63,7 +78,7 @@ impl DAQApp {
             pixels_per_point: default_scale,
             serial_ports: util::get_avaible_serial_ports(),
             selected_serial,
-            dbc_path,
+            parser: ParserInfo::new_maybe(settings.dbc_path),
             connection_error: None,
             can_messages: Vec::new(),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{can, settings, shortcuts, theme, ui, util, widgets, workspace};
+use crate::{action, can, settings, shortcuts, theme, ui, util, widgets, workspace};
 use eframe::egui;
 
 const MIN_UI_SCALE: f32 = 0.4;
@@ -29,7 +29,7 @@ pub struct DAQApp {
     pub next_log_parser_num: usize,
     pub can_receiver: std::sync::mpsc::Receiver<can::can_messages::CanMessage>,
     pub ui_sender: std::sync::mpsc::Sender<ui::ui_messages::UiMessage>,
-    pub pending_scope_spawns: Vec<(u32, String, String)>,
+    pub action_queue: Vec<action::AppAction>,
     pub theme: egui::Style,
     pub theme_selection: theme::ThemeSelection,
     pub pixels_per_point: f32,
@@ -72,7 +72,7 @@ impl DAQApp {
             next_log_parser_num: 1,
             can_receiver,
             ui_sender,
-            pending_scope_spawns: Vec::new(),
+            action_queue: Vec::new(),
             theme: theme_style,
             theme_selection,
             pixels_per_point: default_scale,
@@ -111,48 +111,58 @@ impl DAQApp {
         tabs.set_active(new_tile_id);
     }
 
-    pub fn spawn_viewer_table(&mut self) {
-        let widget = widgets::Widget::ViewerTable(ui::viewer_table::ViewerTable::new(
-            self.next_can_viewer_num,
-        ));
-        self.next_can_viewer_num += 1;
-        self.add_widget_to_tree(widget);
-    }
+    pub fn handle_action(&mut self, action: action::AppAction) {
+        match action {
+            action::AppAction::SpawnWidget(widget_type) => {
+                let widget = match &widget_type {
+                    action::WidgetType::ViewerTable => widgets::Widget::ViewerTable(
+                        ui::viewer_table::ViewerTable::new(self.next_can_viewer_num),
+                    ),
+                    action::WidgetType::ViewerList => widgets::Widget::ViewerList(
+                        ui::viewer_list::ViewerList::new(self.next_can_viewer_num),
+                    ),
+                    action::WidgetType::Bootloader => widgets::Widget::Bootloader(
+                        ui::bootloader::Bootloader::new(self.next_bootloader_num),
+                    ),
+                    action::WidgetType::Scope {
+                        msg_id,
+                        msg_name,
+                        signal_name,
+                    } => widgets::Widget::Scope(ui::scope::Scope::new(
+                        self.next_scope_num,
+                        msg_id.clone(),
+                        msg_name.clone(),
+                        signal_name.clone(),
+                    )),
+                    action::WidgetType::LogParser => widgets::Widget::LogParser(
+                        ui::log_parser::LogParser::new(self.next_log_parser_num),
+                    ),
+                };
+                self.add_widget_to_tree(widget);
 
-    pub fn spawn_viewer_list(&mut self) {
-        let widget =
-            widgets::Widget::ViewerList(ui::viewer_list::ViewerList::new(self.next_can_viewer_num));
-        self.next_can_viewer_num += 1;
-        self.add_widget_to_tree(widget);
-    }
-
-    pub fn spawn_bootloader(&mut self) {
-        let widget =
-            widgets::Widget::Bootloader(ui::bootloader::Bootloader::new(self.next_bootloader_num));
-        self.next_bootloader_num += 1;
-        self.add_widget_to_tree(widget);
-    }
-
-    pub fn spawn_scope(&mut self, msg_id: u32, msg_name: String, signal_name: String) {
-        let widget = widgets::Widget::Scope(ui::scope::Scope::new(
-            self.next_scope_num,
-            msg_id,
-            msg_name,
-            signal_name,
-        ));
-        self.next_scope_num += 1;
-        self.add_widget_to_tree(widget);
-    }
-
-    pub fn spawn_log_parser(&mut self) {
-        let widget =
-            widgets::Widget::LogParser(ui::log_parser::LogParser::new(self.next_log_parser_num));
-        self.next_log_parser_num += 1;
-        self.add_widget_to_tree(widget);
+                // Increment the appropriate counter
+                match widget_type {
+                    action::WidgetType::ViewerTable | action::WidgetType::ViewerList => {
+                        self.next_can_viewer_num += 1;
+                    }
+                    action::WidgetType::Bootloader => {
+                        self.next_bootloader_num += 1;
+                    }
+                    action::WidgetType::Scope { .. } => {
+                        self.next_scope_num += 1;
+                    }
+                    action::WidgetType::LogParser => {
+                        self.next_log_parser_num += 1;
+                    }
+                }
+            }
+            action::AppAction::CloseTile(tile_id) => {
+                self.tile_tree.tiles.remove(tile_id);
+            }
+        }
     }
 
     pub fn toggle_theme(&mut self) {
-        // Update theme selection to the next option
         self.theme_selection = self.theme_selection.next();
         self.theme = self.theme_selection.get_style();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,6 @@ pub struct DAQApp {
     pub pixels_per_point: f32,
     pub serial_ports: Vec<serialport::SerialPortInfo>,
     pub parser: Option<ParserInfo>,
-    pub connection_error: Option<String>,
     pub udp_port: u16,
     pub can_messages: Vec<can::can_messages::CanMessage>,
 }
@@ -89,7 +88,6 @@ impl DAQApp {
             pixels_per_point: default_scale,
             serial_ports: util::get_avaible_serial_ports(),
             parser: ParserInfo::new_maybe(settings.dbc_path),
-            connection_error: None,
             udp_port: settings.udp_port,
             can_messages: Vec::new(),
         }
@@ -212,10 +210,13 @@ impl eframe::App for DAQApp {
         while let Ok(msg) = self.can_receiver.try_recv() {
             match &msg {
                 can::can_messages::CanMessage::ConnectionFailed(port) => {
-                    self.connection_error = Some(format!("Failed to connect to {port}"));
+                    self.connection_status = ConnectionStatus::Error(format!("Failed to connect to {port}"));
                 }
                 can::can_messages::CanMessage::ConnectionSuccessful => {
-                    self.connection_error = None;
+                    self.connection_status = ConnectionStatus::Connected;
+                }
+                can::can_messages::CanMessage::Disconnection => {
+                    self.connection_status = ConnectionStatus::Disconnected;
                 }
                 _ => {
                     self.can_messages.push(msg);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,17 +1,9 @@
-use crate::{can, config, shortcuts, ui, widgets, workspace};
-use eframe::egui::{self};
-use serde::{Deserialize, Serialize};
+use crate::{can, shortcuts, ui, widgets, settings, workspace, theme};
+use eframe::egui;
 use serialport::available_ports;
-use std::fs;
-pub(crate) const SETTINGS_PATH: &str = "settings.json";
-const NORD_THEME_PATH: &str = "themes/nord.toml";
-const CATPPUCCIN_THEME_PATH: &str = "themes/catppuccin.toml";
-#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
-pub enum ThemeSelection {
-    Default,
-    Nord,
-    Catppuccin,
-}
+
+const MIN_UI_SCALE: f32 = 0.4;
+const MAX_UI_SCALE: f32 = 5.0;
 
 pub struct DAQApp {
     pub is_sidebar_open: bool,
@@ -24,7 +16,7 @@ pub struct DAQApp {
     pub ui_sender: std::sync::mpsc::Sender<ui::ui_messages::UiMessage>,
     pub pending_scope_spawns: Vec<(u32, String, String)>,
     pub theme: egui::Style,
-    pub theme_selection: ThemeSelection,
+    pub theme_selection: theme::ThemeSelection,
     pub pixels_per_point: f32,
     pub selected_serial: Option<String>,
     pub serial_ports: Vec<serialport::SerialPortInfo>,
@@ -33,74 +25,27 @@ pub struct DAQApp {
     pub can_messages: Vec<can::can_messages::CanMessage>,
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct Settings {
-    pub dbc_path: Option<std::path::PathBuf>,
-    pub selected_serial: Option<String>,
-    pub theme: ThemeSelection,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            theme: ThemeSelection::Default,
-            dbc_path: None,
-            selected_serial: None,
-        }
-    }
-}
-
-impl Settings {
-    pub fn load(path: &str) -> Self {
-        if let Ok(json) = fs::read_to_string(path) {
-            serde_json::from_str(&json).unwrap_or_default()
-        } else {
-            let default = Settings::default();
-            default.save(path);
-            default
-        }
-    }
-
-    pub fn save(&self, path: &str) {
-        let json = serde_json::to_string_pretty(self).expect("Failed to serialize settings");
-        fs::write(path, json).unwrap_or_else(|e| log::error!("Failed to write {}: {}", path, e));
-    }
-}
-
-const MIN_UI_SCALE: f32 = 0.4;
-const MAX_UI_SCALE: f32 = 5.0;
-
 impl DAQApp {
     pub fn save_settings(&self) {
-        let settings = Settings {
+        let settings = settings::Settings {
             dbc_path: self.dbc_path.clone(),
             selected_serial: self.selected_serial.clone(),
             theme: self.theme_selection,
         };
-        settings.save(SETTINGS_PATH);
+        settings.save();
     }
 
     pub fn new(
         can_receiver: std::sync::mpsc::Receiver<can::can_messages::CanMessage>,
         ui_sender: std::sync::mpsc::Sender<ui::ui_messages::UiMessage>,
+        settings: settings::Settings,
         cc: &eframe::CreationContext,
     ) -> Self {
         // Calculate a default ui scale based off the native_pixels_per_point
         let native_ppp = cc.egui_ctx.native_pixels_per_point().unwrap_or(1.0);
         let default_scale = (native_ppp * 2.4).clamp(MIN_UI_SCALE, MAX_UI_SCALE);
-        let settings = Settings::load(SETTINGS_PATH);
         let theme_selection = settings.theme;
-        let theme = match theme_selection {
-            ThemeSelection::Default => egui::Style::default(),
-            ThemeSelection::Nord => config::ThemeColors::load_from_file(NORD_THEME_PATH)
-                .map(|t| t.to_egui_style())
-                .unwrap_or_default(),
-            ThemeSelection::Catppuccin => {
-                config::ThemeColors::load_from_file(CATPPUCCIN_THEME_PATH)
-                    .map(|t| t.to_egui_style())
-                    .unwrap_or_default()
-            }
-        };
+        let theme_style = theme_selection.get_style();
 
         let selected_serial = settings.selected_serial.clone();
         let dbc_path = settings.dbc_path.clone();
@@ -114,7 +59,7 @@ impl DAQApp {
             can_receiver,
             ui_sender,
             pending_scope_spawns: Vec::new(),
-            theme,
+            theme: theme_style,
             theme_selection,
             pixels_per_point: default_scale,
             serial_ports: available_ports()
@@ -205,24 +150,8 @@ impl DAQApp {
 
     pub fn toggle_theme(&mut self) {
         // Update theme selection to the next option
-        self.theme_selection = match self.theme_selection {
-            ThemeSelection::Default => ThemeSelection::Nord,
-            ThemeSelection::Nord => ThemeSelection::Catppuccin,
-            ThemeSelection::Catppuccin => ThemeSelection::Default,
-        };
-
-        // Load the selected theme into the actual field
-        self.theme = match self.theme_selection {
-            ThemeSelection::Default => egui::Style::default(),
-            ThemeSelection::Nord => config::ThemeColors::load_from_file(NORD_THEME_PATH)
-                .map(|t| t.to_egui_style())
-                .unwrap_or_default(),
-            ThemeSelection::Catppuccin => {
-                config::ThemeColors::load_from_file(CATPPUCCIN_THEME_PATH)
-                    .map(|t| t.to_egui_style())
-                    .unwrap_or_default()
-            }
-        };
+        self.theme_selection = self.theme_selection.next();
+        self.theme = self.theme_selection.get_style();
     }
 
     // Close the currently active widget in the tile tree

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ impl ParserInfo {
         Self { dbc_path, parser }
     }
     pub fn new_maybe(dbc_path: Option<std::path::PathBuf>) -> Option<Self> {
-        dbc_path.map(|path| Self::new(path))
+        dbc_path.map(Self::new)
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -207,7 +207,8 @@ impl eframe::App for DAQApp {
         while let Ok(msg) = self.can_receiver.try_recv() {
             match &msg {
                 can::can_messages::CanMessage::ConnectionFailed(port) => {
-                    self.connection_status = ConnectionStatus::Error(format!("Failed to connect to {port}"));
+                    self.connection_status =
+                        ConnectionStatus::Error(format!("Failed to connect to {port}"));
                 }
                 can::can_messages::CanMessage::ConnectionSuccessful => {
                     self.connection_status = ConnectionStatus::Connected;

--- a/src/app.rs
+++ b/src/app.rs
@@ -130,7 +130,7 @@ impl DAQApp {
                         signal_name,
                     } => widgets::Widget::Scope(ui::scope::Scope::new(
                         self.next_scope_num,
-                        msg_id.clone(),
+                        *msg_id,
                         msg_name.clone(),
                         signal_name.clone(),
                     )),
@@ -224,6 +224,11 @@ impl eframe::App for DAQApp {
         ui::sidebar::show(self, ctx);
 
         workspace::show(self, ctx);
+
+        // Drain the action queue and handle all actions
+        for action in std::mem::take(&mut self.action_queue) {
+            self.handle_action(action);
+        }
 
         ctx.request_repaint();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -177,9 +177,6 @@ impl DAQApp {
                     }
                 }
             }
-            action::AppAction::CloseTile(tile_id) => {
-                self.tile_tree.tiles.remove(tile_id);
-            }
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{action, can, settings, shortcuts, theme, ui, util, widgets, workspace};
+use crate::{action, can, connection, settings, shortcuts, theme, ui, util, widgets, workspace};
 use eframe::egui;
 
 const MIN_UI_SCALE: f32 = 0.4;
@@ -20,7 +20,15 @@ impl ParserInfo {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub enum ConnectionStatus {
+    Disconnected,
+    Connected,
+    Error(String),
+}
+
 pub struct DAQApp {
+    pub connection_status: ConnectionStatus,
     pub is_sidebar_open: bool,
     pub tile_tree: egui_tiles::Tree<widgets::Widget>,
     pub next_can_viewer_num: usize,
@@ -30,13 +38,14 @@ pub struct DAQApp {
     pub can_receiver: std::sync::mpsc::Receiver<can::can_messages::CanMessage>,
     pub ui_sender: std::sync::mpsc::Sender<ui::ui_messages::UiMessage>,
     pub action_queue: Vec<action::AppAction>,
+    pub selected_source: Option<connection::ConnectionSource>,
     pub theme: egui::Style,
     pub theme_selection: theme::ThemeSelection,
     pub pixels_per_point: f32,
-    pub selected_serial: Option<String>,
     pub serial_ports: Vec<serialport::SerialPortInfo>,
     pub parser: Option<ParserInfo>,
     pub connection_error: Option<String>,
+    pub udp_port: u16,
     pub can_messages: Vec<can::can_messages::CanMessage>,
 }
 
@@ -44,7 +53,8 @@ impl DAQApp {
     pub fn save_settings(&self) {
         let settings = settings::Settings {
             dbc_path: self.parser.as_ref().map(|p| p.dbc_path.clone()),
-            selected_serial: self.selected_serial.clone(),
+            selected_source: self.selected_source.clone(),
+            udp_port: self.udp_port,
             theme: self.theme_selection,
         };
         settings.save();
@@ -62,8 +72,8 @@ impl DAQApp {
         let theme_selection = settings.theme;
         let theme_style = theme_selection.get_style();
 
-        let selected_serial = settings.selected_serial.clone();
         Self {
+            connection_status: ConnectionStatus::Disconnected,
             is_sidebar_open: true,
             tile_tree: egui_tiles::Tree::empty("workspace_tree"),
             next_can_viewer_num: 1,
@@ -73,13 +83,14 @@ impl DAQApp {
             can_receiver,
             ui_sender,
             action_queue: Vec::new(),
+            selected_source: settings.selected_source,
             theme: theme_style,
             theme_selection,
             pixels_per_point: default_scale,
             serial_ports: util::get_avaible_serial_ports(),
-            selected_serial,
             parser: ParserInfo::new_maybe(settings.dbc_path),
             connection_error: None,
+            udp_port: settings.udp_port,
             can_messages: Vec::new(),
         }
     }
@@ -109,6 +120,18 @@ impl DAQApp {
         // Root is already a tab container, add to it
         tabs.add_child(new_tile_id);
         tabs.set_active(new_tile_id);
+    }
+
+    pub fn connect_can(&mut self) {
+        let Some(source) = &self.selected_source else {
+            return;
+        };
+
+        self.connection_status = ConnectionStatus::Disconnected;
+
+        let _ = self
+            .ui_sender
+            .send(ui::ui_messages::UiMessage::Connect(source.clone()));
     }
 
     pub fn handle_action(&mut self, action: action::AppAction) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{can, shortcuts, ui, widgets, settings, workspace, theme};
+use crate::{can, settings, shortcuts, theme, ui, widgets, workspace};
 use eframe::egui;
 use serialport::available_ports;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,5 @@
-use crate::{can, settings, shortcuts, theme, ui, widgets, workspace};
+use crate::{can, settings, shortcuts, theme, util, ui, widgets, workspace};
 use eframe::egui;
-use serialport::available_ports;
 
 const MIN_UI_SCALE: f32 = 0.4;
 const MAX_UI_SCALE: f32 = 5.0;
@@ -62,18 +61,7 @@ impl DAQApp {
             theme: theme_style,
             theme_selection,
             pixels_per_point: default_scale,
-            serial_ports: available_ports()
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|p| {
-                    let name = p.port_name.to_lowercase();
-                    if cfg!(target_os = "windows") {
-                        name.starts_with("com")
-                    } else {
-                        name.starts_with("/dev/tty.usbmodem") || name.starts_with("/dev/ttyacm")
-                    }
-                })
-                .collect(),
+            serial_ports: util::get_avaible_serial_ports(),
             selected_serial,
             dbc_path,
             connection_error: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ pub struct DAQApp {
     pub serial_ports: Vec<serialport::SerialPortInfo>,
     pub parser: Option<ParserInfo>,
     pub udp_port: u16,
-    pub can_messages: Vec<can::can_messages::CanMessage>,
+    pub can_messages: Vec<can::message::ParsedMessage>,
 }
 
 impl DAQApp {
@@ -215,8 +215,8 @@ impl eframe::App for DAQApp {
                 can::can_messages::CanMessage::Disconnection => {
                     self.connection_status = ConnectionStatus::Disconnected;
                 }
-                _ => {
-                    self.can_messages.push(msg);
+                can::can_messages::CanMessage::ParsedMessage(parsed) => {
+                    self.can_messages.push(parsed.clone());
                 }
             }
         }

--- a/src/can/can_messages.rs
+++ b/src/can/can_messages.rs
@@ -2,6 +2,7 @@ use crate::can;
 
 pub enum CanMessage {
     ParsedMessage(can::message::ParsedMessage),
-    ConnectionFailed(String),
+    Disconnection,
     ConnectionSuccessful,
+    ConnectionFailed(String),
 }

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -10,9 +10,16 @@ const SERIAL_TIMEOUT_MS: u64 = 10;
 pub type DriverResult<T> = Result<T, DriverError>;
 
 #[derive(Debug)]
+pub enum DriverReadError {
+    Timeout,
+    IoError(String),
+    Other(String),
+}
+
+#[derive(Debug)]
 pub enum DriverError {
     ConnectionFailed(String),
-    ReadError(String),
+    ReadError(DriverReadError),
     WriteError(String),
 }
 
@@ -66,15 +73,18 @@ impl Driver for SerialDriver {
                 if io_err.kind() == std::io::ErrorKind::WouldBlock
                     || io_err.kind() == std::io::ErrorKind::TimedOut
                 {
-                    DriverError::ReadError("Timeout".to_string())
+                    DriverError::ReadError(DriverReadError::Timeout)
                 } else {
                     self.connected = false;
-                    DriverError::ReadError(format!("IO error: {}", io_err))
+                    DriverError::ReadError(DriverReadError::IoError(format!(
+                        "I/O error: {}",
+                        io_err
+                    )))
                 }
             }
             other => {
                 self.connected = false;
-                DriverError::ReadError(format!("Read error: {}", other))
+                DriverError::ReadError(DriverReadError::Other(format!("Read error: {:?}", other)))
             }
         })
     }
@@ -113,7 +123,9 @@ impl Driver for UdpDriver {
     fn read_frame(&mut self) -> DriverResult<CanFrame> {
         // TODO: possibly need to handle the the fact that one UDP packet could contain multiple CAN frames
         // and the data is in PER DAQ log format, not raw CAN frames
-        Err(DriverError::ReadError("UDP not implemented".to_string()))
+        Err(DriverError::ReadError(DriverReadError::Other(
+            "UDP read not implemented".to_string(),
+        )))
     }
 
     fn is_connected(&self) -> bool {

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -1,0 +1,134 @@
+use crate::connection::ConnectionSource;
+use serialport::{ClearBuffer, SerialPort};
+use slcan::sync::CanSocket;
+use slcan::{CanFrame, NominalBitRate, OperatingMode};
+use std::time::Duration;
+
+const SERIAL_BAUD_RATE: u32 = 115_200;
+const SERIAL_TIMEOUT_MS: u64 = 10;
+
+pub type DriverResult<T> = Result<T, DriverError>;
+
+#[derive(Debug)]
+pub enum DriverError {
+    ConnectionFailed(String),
+    ReadError(String),
+    WriteError(String),
+}
+
+pub trait Driver {
+    fn read_frame(&mut self) -> DriverResult<CanFrame>;
+
+    fn is_connected(&self) -> bool;
+
+    fn close(&mut self) -> DriverResult<()>;
+}
+
+/// Serial CAN driver using SLCAN protocol
+pub struct SerialDriver {
+    socket: CanSocket<Box<dyn SerialPort>>,
+    connected: bool,
+}
+
+impl SerialDriver {
+    pub fn new(port_path: &str) -> DriverResult<Self> {
+        let port = serialport::new(port_path, SERIAL_BAUD_RATE)
+            .timeout(Duration::from_millis(SERIAL_TIMEOUT_MS))
+            .open()
+            .map_err(|e| {
+                DriverError::ConnectionFailed(format!("Failed to open port {}: {}", port_path, e))
+            })?;
+
+        let _ = port.clear(ClearBuffer::All);
+        let mut socket = CanSocket::new(port.try_clone().expect("Failed to clone serial port"));
+
+        socket
+            .set_operating_mode(OperatingMode::Normal)
+            .map_err(|e| {
+                DriverError::ConnectionFailed(format!("Failed to set operating mode: {}", e))
+            })?;
+
+        socket
+            .open(NominalBitRate::Rate500Kbit)
+            .map_err(|e| DriverError::ConnectionFailed(format!("Failed to open CAN: {}", e)))?;
+
+        Ok(Self {
+            socket,
+            connected: true,
+        })
+    }
+}
+
+impl Driver for SerialDriver {
+    fn read_frame(&mut self) -> DriverResult<CanFrame> {
+        self.socket.read().map_err(|e| match e {
+            slcan::ReadError::Io(io_err) => {
+                if io_err.kind() == std::io::ErrorKind::WouldBlock
+                    || io_err.kind() == std::io::ErrorKind::TimedOut
+                {
+                    DriverError::ReadError("Timeout".to_string())
+                } else {
+                    self.connected = false;
+                    DriverError::ReadError(format!("IO error: {}", io_err))
+                }
+            }
+            other => {
+                self.connected = false;
+                DriverError::ReadError(format!("Read error: {}", other))
+            }
+        })
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn close(&mut self) -> DriverResult<()> {
+        self.socket
+            .close()
+            .map_err(|e| DriverError::WriteError(format!("Failed to close: {}", e)))?;
+        self.connected = false;
+        Ok(())
+    }
+}
+
+/// UDP CAN driver (placeholder for future implementation)
+pub struct UdpDriver {
+    port: u16,
+    connected: bool,
+}
+
+impl UdpDriver {
+    /// Create a new UDP driver
+    pub fn new(port: u16) -> DriverResult<Self> {
+        // TODO: Implement UDP connection
+        log::warn!("UDP driver not yet implemented");
+        Err(DriverError::ConnectionFailed(
+            "UDP not implemented".to_string(),
+        ))
+    }
+}
+
+impl Driver for UdpDriver {
+    fn read_frame(&mut self) -> DriverResult<CanFrame> {
+        // TODO: possibly need to handle the the fact that one UDP packet could contain multiple CAN frames
+        // and the data is in PER DAQ log format, not raw CAN frames
+        Err(DriverError::ReadError("UDP not implemented".to_string()))
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn close(&mut self) -> DriverResult<()> {
+        self.connected = false;
+        Ok(())
+    }
+}
+
+pub fn create_driver(source: &ConnectionSource) -> DriverResult<Box<dyn Driver>> {
+    match source {
+        ConnectionSource::Serial(path) => Ok(Box::new(SerialDriver::new(path)?)),
+        ConnectionSource::Udp(port) => Ok(Box::new(UdpDriver::new(*port)?)),
+    }
+}

--- a/src/can/mod.rs
+++ b/src/can/mod.rs
@@ -1,4 +1,5 @@
 pub mod can_messages;
+pub mod driver;
 pub mod message;
 pub mod state;
 pub mod thread;

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -63,42 +63,42 @@ pub fn start_can_thread(
             }
 
             if can.is_none()
-                && let Some(ref path) = serial_path {
-                    let port = match serialport::new(path, BAUD_RATE)
-                        .timeout(Duration::from_millis(10))
-                        .open()
-                    {
-                        Ok(p) => p,
-                        Err(e) => {
-                            log::error!("Failed to open serialport {}: {e}", path);
-                            pending_connection_error = Some(path.clone());
-                            thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
-                            continue;
-                        }
-                    };
-                    let _ = port.clear(ClearBuffer::All);
-                    let mut socket =
-                        CanSocket::new(port.try_clone().expect("clone serialport failed"));
-                    if let Err(e) = socket.set_operating_mode(OperatingMode::Normal) {
-                        log::error!("Failed to set operating mode: {e}");
-                        state.is_connected = false;
+                && let Some(ref path) = serial_path
+            {
+                let port = match serialport::new(path, BAUD_RATE)
+                    .timeout(Duration::from_millis(10))
+                    .open()
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        log::error!("Failed to open serialport {}: {e}", path);
                         pending_connection_error = Some(path.clone());
                         thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
                         continue;
                     }
-                    if let Err(e) = socket.open(NominalBitRate::Rate500Kbit) {
-                        log::error!("Failed to open CAN: {e}");
-                        state.is_connected = false;
-                        pending_connection_error = Some(path.clone());
-                        thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
-                        continue;
-                    }
-                    state.is_connected = true;
-                    let _ = state
-                        .can_sender
-                        .send(can::can_messages::CanMessage::ConnectionSuccessful);
-                    can = Some(socket);
+                };
+                let _ = port.clear(ClearBuffer::All);
+                let mut socket = CanSocket::new(port.try_clone().expect("clone serialport failed"));
+                if let Err(e) = socket.set_operating_mode(OperatingMode::Normal) {
+                    log::error!("Failed to set operating mode: {e}");
+                    state.is_connected = false;
+                    pending_connection_error = Some(path.clone());
+                    thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
+                    continue;
                 }
+                if let Err(e) = socket.open(NominalBitRate::Rate500Kbit) {
+                    log::error!("Failed to open CAN: {e}");
+                    state.is_connected = false;
+                    pending_connection_error = Some(path.clone());
+                    thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
+                    continue;
+                }
+                state.is_connected = true;
+                let _ = state
+                    .can_sender
+                    .send(can::can_messages::CanMessage::ConnectionSuccessful);
+                can = Some(socket);
+            }
 
             // Try to read a frame
             let Some(ref mut can_socket) = can else {

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -66,7 +66,6 @@ pub fn start_can_thread(
     thread::spawn(move || {
         let mut state = can::state::State::new(can_sender, ui_receiver);
         let mut driver: Option<Box<dyn can::driver::Driver>> = None;
-        let mut pending_connection_error: Option<String> = None;
         let mut current_source: Option<connection::ConnectionSource> = selected_source;
 
         if let Some(path) = dbc_path {
@@ -81,12 +80,8 @@ pub fn start_can_thread(
 
         // MAIN LOOP
         loop {
-            if let Some(error_msg) = pending_connection_error.take() {
-                let _ = state
-                    .can_sender
-                    .send(can::can_messages::CanMessage::ConnectionFailed(error_msg));
-            }
             // Process UI messages first (DBC load, etc.)
+            let mut reaction_messages = Vec::new();
             for msg in state.ui_receiver.try_iter() {
                 match msg {
                     ui::ui_messages::UiMessage::DbcSelected(path) => {
@@ -104,6 +99,11 @@ pub fn start_can_thread(
                             let _ = old_driver.close();
                         }
                         state.is_connected = false;
+                        state
+                            .can_sender
+                            .send(can::can_messages::CanMessage::Disconnection)
+                            .expect("Failed to send disconnected message");
+                        reaction_messages.push(can::can_messages::CanMessage::Disconnection);
                         current_source = Some(source);
                     }
                 }
@@ -127,7 +127,10 @@ pub fn start_can_thread(
                                 connection::ConnectionSource::Serial(path) => path.clone(),
                                 connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
                             };
-                            pending_connection_error = Some(error_msg);
+                            state
+                                .can_sender
+                                .send(can::can_messages::CanMessage::ConnectionFailed(error_msg))
+                                .expect("Failed to send connection failed message");
                             thread::sleep(Duration::from_millis(NO_CONNECTION_SLEEP_MS));
                             continue;
                         }
@@ -152,7 +155,6 @@ pub fn start_can_thread(
                 Err(can::driver::DriverError::ReadError(msg)) => {
                     if msg == "Timeout" {
                         // Normal timeout, just retry
-                        log::warn!("Driver read timeout, retrying...");
                         thread::sleep(Duration::from_millis(READ_RETRY_SLEEP_MS));
                     } else {
                         // Actual error, disconnect
@@ -163,7 +165,10 @@ pub fn start_can_thread(
                                 connection::ConnectionSource::Serial(path) => path.clone(),
                                 connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
                             };
-                            pending_connection_error = Some(error_msg);
+                            state
+                                .can_sender
+                                .send(can::can_messages::CanMessage::ConnectionFailed(error_msg))
+                                .expect("Failed to send connection failed message");
                         }
                         driver = None;
                     }

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -81,7 +81,6 @@ pub fn start_can_thread(
         // MAIN LOOP
         loop {
             // Process UI messages first (DBC load, etc.)
-            let mut reaction_messages = Vec::new();
             for msg in state.ui_receiver.try_iter() {
                 match msg {
                     ui::ui_messages::UiMessage::DbcSelected(path) => {
@@ -103,7 +102,6 @@ pub fn start_can_thread(
                             .can_sender
                             .send(can::can_messages::CanMessage::Disconnection)
                             .expect("Failed to send disconnected message");
-                        reaction_messages.push(can::can_messages::CanMessage::Disconnection);
                         current_source = Some(source);
                     }
                 }

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -152,25 +152,32 @@ pub fn start_can_thread(
                 Ok(frame) => {
                     process_can_frame(frame, &state);
                 }
-                Err(can::driver::DriverError::ReadError(msg)) => {
-                    if msg == "Timeout" {
-                        // Normal timeout, just retry
-                        thread::sleep(Duration::from_millis(READ_RETRY_SLEEP_MS));
-                    } else {
-                        // Actual error, disconnect
-                        log::error!("Driver read error: {}", msg);
-                        state.is_connected = false;
-                        if let Some(ref source) = current_source {
-                            let error_msg = match source {
-                                connection::ConnectionSource::Serial(path) => path.clone(),
-                                connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
-                            };
-                            state
-                                .can_sender
-                                .send(can::can_messages::CanMessage::ConnectionFailed(error_msg))
-                                .expect("Failed to send connection failed message");
+                Err(can::driver::DriverError::ReadError(error_type)) => {
+                    match error_type {
+                        can::driver::DriverReadError::Timeout => {
+                            // Normal timeout, just retry
+                            thread::sleep(Duration::from_millis(READ_RETRY_SLEEP_MS));
                         }
-                        driver = None;
+                        other => {
+                            // Actual error, disconnect
+                            log::error!("Driver read error: {:?}", other);
+                            state.is_connected = false;
+                            if let Some(ref source) = current_source {
+                                let error_msg = match source {
+                                    connection::ConnectionSource::Serial(path) => path.clone(),
+                                    connection::ConnectionSource::Udp(port) => {
+                                        format!("UDP:{}", port)
+                                    }
+                                };
+                                state
+                                    .can_sender
+                                    .send(can::can_messages::CanMessage::ConnectionFailed(
+                                        error_msg,
+                                    ))
+                                    .expect("Failed to send connection failed message");
+                            }
+                            driver = None;
+                        }
                     }
                 }
                 Err(e) => {

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -62,8 +62,8 @@ pub fn start_can_thread(
                 }
             }
 
-            if can.is_none() {
-                if let Some(ref path) = serial_path {
+            if can.is_none()
+                && let Some(ref path) = serial_path {
                     let port = match serialport::new(path, BAUD_RATE)
                         .timeout(Duration::from_millis(10))
                         .open()
@@ -99,7 +99,6 @@ pub fn start_can_thread(
                         .send(can::can_messages::CanMessage::ConnectionSuccessful);
                     can = Some(socket);
                 }
-            }
 
             // Try to read a frame
             let Some(ref mut can_socket) = can else {

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -23,9 +23,10 @@ fn process_can_frame(frame: CanFrame, state: &can::state::State) {
                         raw_bytes: data.to_vec(),
                         decoded,
                     };
-                    let _ = state
+                    state
                         .can_sender
-                        .send(can::can_messages::CanMessage::ParsedMessage(parsed_msg));
+                        .send(can::can_messages::CanMessage::ParsedMessage(parsed_msg))
+                        .expect("Failed to send parsed CAN message");
                 } else {
                     log::error!(
                         "Failed to parse: frame ID 0x{:X} ({}), data: {:02X?}",
@@ -114,9 +115,10 @@ pub fn start_can_thread(
                         Ok(new_driver) => {
                             driver = Some(new_driver);
                             state.is_connected = true;
-                            let _ = state
+                            state
                                 .can_sender
-                                .send(can::can_messages::CanMessage::ConnectionSuccessful);
+                                .send(can::can_messages::CanMessage::ConnectionSuccessful)
+                                .expect("Failed to send connection successful message");
                             log::info!("Connected to {:?}", source);
                         }
                         Err(e) => {

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -1,26 +1,73 @@
-use crate::{can, ui};
+use crate::{can, connection, ui};
 use chrono::Local;
-use serialport::ClearBuffer;
-use serialport::SerialPort;
-use slcan::sync::CanSocket;
-use slcan::{CanFrame, NominalBitRate, OperatingMode, ReadError};
-use std::{io, thread, time::Duration};
+use slcan::CanFrame;
+use std::{thread, time::Duration};
 
-const BAUD_RATE: u32 = 115_200;
-const NO_PORT_SLEEP_MS: u64 = 200;
+const NO_CONNECTION_SLEEP_MS: u64 = 200;
 const READ_RETRY_SLEEP_MS: u64 = 2;
+
+fn process_can_frame(frame: CanFrame, state: &can::state::State) {
+    match frame {
+        CanFrame::Can2(frame2) => {
+            let id = match frame2.id() {
+                slcan::Id::Standard(sid) => sid.as_raw() as u32,
+                slcan::Id::Extended(eid) => eid.as_raw(),
+            };
+
+            let data = frame2.data().unwrap_or(&[]);
+
+            if let Some(parser) = state.parser.as_ref() {
+                if let Some(decoded) = parser.decode_msg(id, data) {
+                    let parsed_msg = can::message::ParsedMessage {
+                        timestamp: Local::now(),
+                        raw_bytes: data.to_vec(),
+                        decoded,
+                    };
+                    let _ = state
+                        .can_sender
+                        .send(can::can_messages::CanMessage::ParsedMessage(parsed_msg));
+                } else {
+                    log::error!(
+                        "Failed to parse: frame ID 0x{:X} ({}), data: {:02X?}",
+                        id,
+                        id,
+                        data
+                    );
+                }
+            } else {
+                log::warn!(
+                    "No DBC loaded. Received frame ID 0x{:X} ({}), data: {:02X?}",
+                    id,
+                    id,
+                    data
+                );
+            }
+        }
+        CanFrame::CanFd(frame_fd) => {
+            let id = match frame_fd.id() {
+                slcan::Id::Standard(sid) => sid.as_raw() as u32,
+                slcan::Id::Extended(eid) => eid.as_raw(),
+            };
+            log::warn!(
+                "Received CAN FD frame id=0x{:X} len={}",
+                id,
+                frame_fd.data().len()
+            );
+        }
+    }
+}
 
 pub fn start_can_thread(
     can_sender: std::sync::mpsc::Sender<can::can_messages::CanMessage>,
     ui_receiver: std::sync::mpsc::Receiver<ui::ui_messages::UiMessage>,
-    selected_serial: Option<String>,
+    selected_source: Option<connection::ConnectionSource>,
     dbc_path: Option<std::path::PathBuf>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let mut state = can::state::State::new(can_sender, ui_receiver);
-        let mut can: Option<CanSocket<Box<dyn SerialPort>>> = None;
+        let mut driver: Option<Box<dyn can::driver::Driver>> = None;
         let mut pending_connection_error: Option<String> = None;
-        let mut serial_path: Option<String> = selected_serial;
+        let mut current_source: Option<connection::ConnectionSource> = selected_source;
 
         if let Some(path) = dbc_path {
             match can_decode::Parser::from_dbc_file(&path) {
@@ -31,12 +78,13 @@ pub fn start_can_thread(
                 Err(e) => log::error!("Failed to load DBC from settings {:?}: {e}", path),
             }
         }
-        // --- Main loop ---
+
+        // MAIN LOOP
         loop {
-            if let Some(path) = pending_connection_error.take() {
+            if let Some(error_msg) = pending_connection_error.take() {
                 let _ = state
                     .can_sender
-                    .send(can::can_messages::CanMessage::ConnectionFailed(path));
+                    .send(can::can_messages::CanMessage::ConnectionFailed(error_msg));
             }
             // Process UI messages first (DBC load, etc.)
             for msg in state.ui_receiver.try_iter() {
@@ -50,125 +98,80 @@ pub fn start_can_thread(
                             Err(e) => log::error!("Failed to load DBC {:?}: {e}", path),
                         }
                     }
-                    ui::ui_messages::UiMessage::SerialSelected(path) => {
+                    ui::ui_messages::UiMessage::Connect(source) => {
                         // Close existing connection if any
-                        if let Some(mut old) = can.take() {
-                            let _ = old.close();
+                        if let Some(mut old_driver) = driver.take() {
+                            let _ = old_driver.close();
                         }
-
                         state.is_connected = false;
-                        serial_path = Some(path);
+                        current_source = Some(source);
                     }
                 }
             }
 
-            if can.is_none()
-                && let Some(ref path) = serial_path
-            {
-                let port = match serialport::new(path, BAUD_RATE)
-                    .timeout(Duration::from_millis(10))
-                    .open()
-                {
-                    Ok(p) => p,
-                    Err(e) => {
-                        log::error!("Failed to open serialport {}: {e}", path);
-                        pending_connection_error = Some(path.clone());
-                        thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
-                        continue;
+            // Attempt to connect if we don't have a driver but have a source
+            if driver.is_none() {
+                if let Some(ref source) = current_source {
+                    match can::driver::create_driver(source) {
+                        Ok(new_driver) => {
+                            driver = Some(new_driver);
+                            state.is_connected = true;
+                            let _ = state
+                                .can_sender
+                                .send(can::can_messages::CanMessage::ConnectionSuccessful);
+                            log::info!("Connected to {:?}", source);
+                        }
+                        Err(e) => {
+                            log::error!("Failed to create driver for {:?}: {:?}", source, e);
+                            let error_msg = match source {
+                                connection::ConnectionSource::Serial(path) => path.clone(),
+                                connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
+                            };
+                            pending_connection_error = Some(error_msg);
+                            thread::sleep(Duration::from_millis(NO_CONNECTION_SLEEP_MS));
+                            continue;
+                        }
                     }
-                };
-                let _ = port.clear(ClearBuffer::All);
-                let mut socket = CanSocket::new(port.try_clone().expect("clone serialport failed"));
-                if let Err(e) = socket.set_operating_mode(OperatingMode::Normal) {
-                    log::error!("Failed to set operating mode: {e}");
-                    state.is_connected = false;
-                    pending_connection_error = Some(path.clone());
-                    thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
+                } else {
+                    // No source configured, just sleep
+                    thread::sleep(Duration::from_millis(NO_CONNECTION_SLEEP_MS));
                     continue;
                 }
-                if let Err(e) = socket.open(NominalBitRate::Rate500Kbit) {
-                    log::error!("Failed to open CAN: {e}");
-                    state.is_connected = false;
-                    pending_connection_error = Some(path.clone());
-                    thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
-                    continue;
-                }
-                state.is_connected = true;
-                let _ = state
-                    .can_sender
-                    .send(can::can_messages::CanMessage::ConnectionSuccessful);
-                can = Some(socket);
             }
 
-            // Try to read a frame
-            let Some(ref mut can_socket) = can else {
-                thread::sleep(Duration::from_millis(NO_PORT_SLEEP_MS));
+            // Try to read a frame from the driver
+            let Some(ref mut active_driver) = driver else {
+                thread::sleep(Duration::from_millis(NO_CONNECTION_SLEEP_MS));
                 continue;
             };
-            match can_socket.read() {
-                Ok(frame) => match frame {
-                    CanFrame::Can2(frame2) => {
-                        let id = match frame2.id() {
-                            slcan::Id::Standard(sid) => sid.as_raw() as u32,
-                            slcan::Id::Extended(eid) => eid.as_raw(),
-                        };
 
-                        let data = frame2.data().unwrap_or(&[]);
-
-                        if let Some(parser) = state.parser.as_ref() {
-                            if let Some(decoded) = parser.decode_msg(id, data) {
-                                let parsed_msg = can::message::ParsedMessage {
-                                    timestamp: Local::now(),
-                                    raw_bytes: data.to_vec(),
-                                    decoded,
-                                };
-                                let _ = state
-                                    .can_sender
-                                    .send(can::can_messages::CanMessage::ParsedMessage(parsed_msg));
-                            } else {
-                                log::error!(
-                                    "Failed to parse: frame ID 0x{:X} ({}), data: {:02X?}",
-                                    id,
-                                    id,
-                                    data
-                                );
-                            }
-                        } else {
-                            log::warn!(
-                                "No DBC loaded. Received frame ID 0x{:X} ({}), data: {:02X?}",
-                                id,
-                                id,
-                                data
-                            );
-                            continue;
-                        };
+            match active_driver.read_frame() {
+                Ok(frame) => {
+                    process_can_frame(frame, &state);
+                }
+                Err(can::driver::DriverError::ReadError(msg)) => {
+                    if msg == "Timeout" {
+                        // Normal timeout, just retry
+                        log::warn!("Driver read timeout, retrying...");
+                        thread::sleep(Duration::from_millis(READ_RETRY_SLEEP_MS));
+                    } else {
+                        // Actual error, disconnect
+                        log::error!("Driver read error: {}", msg);
+                        state.is_connected = false;
+                        if let Some(ref source) = current_source {
+                            let error_msg = match source {
+                                connection::ConnectionSource::Serial(path) => path.clone(),
+                                connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
+                            };
+                            pending_connection_error = Some(error_msg);
+                        }
+                        driver = None;
                     }
-                    CanFrame::CanFd(frame_fd) => {
-                        // Optional: Handle FD frames differently or log
-                        log::info!("Received frame: {:?}", frame_fd);
-                        let id = match frame_fd.id() {
-                            slcan::Id::Standard(sid) => sid.as_raw() as u32,
-                            slcan::Id::Extended(eid) => eid.as_raw(),
-                        };
-                        log::warn!(
-                            "Received CAN FD frame id=0x{:X} len={}",
-                            id,
-                            frame_fd.data().len()
-                        );
-                    }
-                },
-                Err(ReadError::Io(e))
-                    if e.kind() == io::ErrorKind::WouldBlock
-                        || e.kind() == io::ErrorKind::TimedOut =>
-                {
-                    thread::sleep(Duration::from_millis(READ_RETRY_SLEEP_MS));
                 }
                 Err(e) => {
-                    log::error!("Read error: {e}");
+                    log::error!("Unexpected driver error: {:?}", e);
                     state.is_connected = false;
-                    pending_connection_error = serial_path.clone();
-                    can = None;
-                    continue;
+                    driver = None;
                 }
             }
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,5 @@
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub enum ConnectionSource {
+    Serial(String),
+    Udp(u16),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod can;
+mod connection;
 mod settings;
 mod shortcuts;
 mod theme;
@@ -23,7 +24,7 @@ fn main() -> eframe::Result<()> {
     let _can_thread = can::thread::start_can_thread(
         can_sender,
         ui_receiver,
-        settings.selected_serial.clone(),
+        settings.selected_source.clone(),
         settings.dbc_path.clone(),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod theme;
 mod ui;
 mod widgets;
 mod workspace;
+mod util;
 
 use eframe::egui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod action;
 mod app;
 mod can;
 mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ mod settings;
 mod shortcuts;
 mod theme;
 mod ui;
+mod util;
 mod widgets;
 mod workspace;
-mod util;
 
 use eframe::egui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
-use crate::app::Settings;
-
 mod app;
 mod can;
-mod config;
+mod settings;
 mod shortcuts;
+mod theme;
 mod ui;
 mod widgets;
 mod workspace;
@@ -17,7 +16,7 @@ fn main() -> eframe::Result<()> {
 
     let (can_sender, can_receiver) = std::sync::mpsc::channel::<can::can_messages::CanMessage>();
     let (ui_sender, ui_receiver) = std::sync::mpsc::channel::<ui::ui_messages::UiMessage>();
-    let settings = Settings::load(app::SETTINGS_PATH);
+    let settings = settings::Settings::load();
 
     let _can_thread = can::thread::start_can_thread(
         can_sender,
@@ -37,6 +36,13 @@ fn main() -> eframe::Result<()> {
     eframe::run_native(
         "DaqApp2",
         options,
-        Box::new(|cc| Ok(Box::new(app::DAQApp::new(can_receiver, ui_sender, cc)))),
+        Box::new(|cc| {
+            Ok(Box::new(app::DAQApp::new(
+                can_receiver,
+                ui_sender,
+                settings,
+                cc,
+            )))
+        }),
     )
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,20 +1,23 @@
-use crate::theme;
+use crate::{connection, theme};
 
 pub const SETTINGS_PATH: &str = "settings.json";
+const DEFAULT_UDP_PORT: u16 = 5000;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Settings {
     pub dbc_path: Option<std::path::PathBuf>,
-    pub selected_serial: Option<String>,
+    pub selected_source: Option<connection::ConnectionSource>,
+    pub udp_port: u16,
     pub theme: theme::ThemeSelection,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            theme: theme::ThemeSelection::Default,
             dbc_path: None,
-            selected_serial: None,
+            selected_source: None,
+            udp_port: DEFAULT_UDP_PORT,
+            theme: theme::ThemeSelection::Default,
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,38 @@
+use crate::theme;
+
+pub const SETTINGS_PATH: &str = "settings.json";
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Settings {
+    pub dbc_path: Option<std::path::PathBuf>,
+    pub selected_serial: Option<String>,
+    pub theme: theme::ThemeSelection,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            theme: theme::ThemeSelection::Default,
+            dbc_path: None,
+            selected_serial: None,
+        }
+    }
+}
+
+impl Settings {
+    pub fn load() -> Self {
+        if let Ok(json) = std::fs::read_to_string(SETTINGS_PATH) {
+            serde_json::from_str(&json).unwrap_or_default()
+        } else {
+            let default = Settings::default();
+            default.save();
+            default
+        }
+    }
+
+    pub fn save(&self) {
+        let json = serde_json::to_string_pretty(self).expect("Failed to serialize settings");
+        std::fs::write(SETTINGS_PATH, json)
+            .unwrap_or_else(|e| log::error!("Failed to write {}: {}", SETTINGS_PATH, e));
+    }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,7 +1,49 @@
-use eframe::egui::{self, Color32};
-use serde::Deserialize;
+use eframe::egui;
 
-#[derive(Debug, Deserialize, Clone)]
+const NORD_THEME_PATH: &str = "themes/nord.toml";
+const CATPPUCCIN_THEME_PATH: &str = "themes/catppuccin.toml";
+
+
+#[derive(Copy, Clone, serde::Serialize, serde::Deserialize, Debug)]
+pub enum ThemeSelection {
+    Default,
+    Nord,
+    Catppuccin,
+}
+
+impl ThemeSelection {
+    pub fn to_name(&self) -> &'static str {
+        match self {
+            ThemeSelection::Default => "Default",
+            ThemeSelection::Nord => "Nord",
+            ThemeSelection::Catppuccin => "Catppuccin",
+        }
+    }
+
+	pub fn get_style(&self) -> egui::Style {
+		match self {
+			ThemeSelection::Default => egui::Style::default(),
+			ThemeSelection::Nord => ThemeColors::load_from_file(NORD_THEME_PATH)
+				.map(|t| t.to_egui_style())
+				.unwrap_or_default(),
+			ThemeSelection::Catppuccin => {
+				ThemeColors::load_from_file(CATPPUCCIN_THEME_PATH)
+					.map(|t| t.to_egui_style())
+					.unwrap_or_default()
+			}
+		}
+	}
+
+    pub fn next(&self) -> Self {
+        match self {
+            ThemeSelection::Default => ThemeSelection::Nord,
+            ThemeSelection::Nord => ThemeSelection::Catppuccin,
+            ThemeSelection::Catppuccin => ThemeSelection::Default,
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize, Clone)]
 pub struct ThemeColors {
     pub background: String,
     pub panel_bg: String,
@@ -13,7 +55,7 @@ pub struct ThemeColors {
 }
 
 impl ThemeColors {
-    pub fn parse_hex(hex: &str) -> Color32 {
+    pub fn parse_hex(hex: &str) -> egui::Color32 {
         let hex = hex.trim_start_matches('#');
 
         match hex.len() {
@@ -21,16 +63,16 @@ impl ThemeColors {
                 let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
                 let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
                 let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
-                Color32::from_rgb(r, g, b)
+                egui::Color32::from_rgb(r, g, b)
             }
             8 => {
                 let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
                 let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
                 let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
                 let a = u8::from_str_radix(&hex[6..8], 16).unwrap_or(255);
-                Color32::from_rgba_unmultiplied(r, g, b, a)
+                egui::Color32::from_rgba_unmultiplied(r, g, b, a)
             }
-            _ => Color32::from_rgb(255, 0, 255), // fallback magenta for invalid
+            _ => egui::Color32::from_rgb(255, 0, 255), // fallback magenta for invalid
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -3,7 +3,6 @@ use eframe::egui;
 const NORD_THEME_PATH: &str = "themes/nord.toml";
 const CATPPUCCIN_THEME_PATH: &str = "themes/catppuccin.toml";
 
-
 #[derive(Copy, Clone, serde::Serialize, serde::Deserialize, Debug)]
 pub enum ThemeSelection {
     Default,
@@ -20,19 +19,17 @@ impl ThemeSelection {
         }
     }
 
-	pub fn get_style(&self) -> egui::Style {
-		match self {
-			ThemeSelection::Default => egui::Style::default(),
-			ThemeSelection::Nord => ThemeColors::load_from_file(NORD_THEME_PATH)
-				.map(|t| t.to_egui_style())
-				.unwrap_or_default(),
-			ThemeSelection::Catppuccin => {
-				ThemeColors::load_from_file(CATPPUCCIN_THEME_PATH)
-					.map(|t| t.to_egui_style())
-					.unwrap_or_default()
-			}
-		}
-	}
+    pub fn get_style(&self) -> egui::Style {
+        match self {
+            ThemeSelection::Default => egui::Style::default(),
+            ThemeSelection::Nord => ThemeColors::load_from_file(NORD_THEME_PATH)
+                .map(|t| t.to_egui_style())
+                .unwrap_or_default(),
+            ThemeSelection::Catppuccin => ThemeColors::load_from_file(CATPPUCCIN_THEME_PATH)
+                .map(|t| t.to_egui_style())
+                .unwrap_or_default(),
+        }
+    }
 
     pub fn next(&self) -> Self {
         match self {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -11,7 +11,7 @@ pub enum ThemeSelection {
 }
 
 impl ThemeSelection {
-    pub fn to_name(&self) -> &'static str {
+    pub fn get_name(&self) -> &'static str {
         match self {
             ThemeSelection::Default => "Default",
             ThemeSelection::Nord => "Nord",

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -1,3 +1,4 @@
+use crate::app;
 use eframe::egui;
 
 pub struct LogParser {
@@ -52,7 +53,7 @@ impl LogParser {
     pub fn show(
         &mut self,
         ui: &mut egui::Ui,
-        dbc_path: Option<&std::path::PathBuf>,
+        parser: Option<&app::ParserInfo>,
     ) -> egui_tiles::UiResponse {
         ui.heading(format!("🔧 {}", self.title));
         ui.separator();

--- a/src/ui/scope.rs
+++ b/src/ui/scope.rs
@@ -1,3 +1,4 @@
+use crate::can;
 use eframe::egui;
 use egui_plot::{Line, Plot, PlotPoints};
 use std::collections::VecDeque;
@@ -156,8 +157,8 @@ impl Scope {
         egui_tiles::UiResponse::None
     }
 
-    pub fn handle_can_message(&mut self, msg: &crate::can::can_messages::CanMessage) {
-        let crate::can::can_messages::CanMessage::ParsedMessage(parsed) = msg else {
+    pub fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
+        let can::can_messages::CanMessage::ParsedMessage(parsed) = msg else {
             return;
         };
 

--- a/src/ui/scope.rs
+++ b/src/ui/scope.rs
@@ -157,19 +157,15 @@ impl Scope {
         egui_tiles::UiResponse::None
     }
 
-    pub fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
-        let can::can_messages::CanMessage::ParsedMessage(parsed) = msg else {
-            return;
-        };
-
-        if parsed.decoded.msg_id != self.msg_id {
+    pub fn handle_can_message(&mut self, msg: &can::message::ParsedMessage) {
+        if msg.decoded.msg_id != self.msg_id {
             return;
         }
 
-        let Some(signal) = parsed.decoded.signals.get(&self.signal_name) else {
+        let Some(signal) = msg.decoded.signals.get(&self.signal_name) else {
             return;
         };
 
-        self.add_point(parsed.timestamp, signal.value);
+        self.add_point(msg.timestamp, signal.value);
     }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -140,9 +140,15 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
             ui.horizontal(|ui| {
                 // Connection status indicator
                 let (status_icon, status_color) = match &app.connection_status {
-                    app::ConnectionStatus::Disconnected => ("⚪ Disconnected".to_string(), egui::Color32::GRAY),
-                    app::ConnectionStatus::Connected => ("🟢 Connected".to_string(), egui::Color32::GREEN),
-                    app::ConnectionStatus::Error(e) => (format!("🔴 Error: {}", e), egui::Color32::RED),
+                    app::ConnectionStatus::Disconnected => {
+                        ("⚪ Disconnected".to_string(), egui::Color32::GRAY)
+                    }
+                    app::ConnectionStatus::Connected => {
+                        ("🟢 Connected".to_string(), egui::Color32::GREEN)
+                    }
+                    app::ConnectionStatus::Error(e) => {
+                        (format!("🔴 Error: {}", e), egui::Color32::RED)
+                    }
                 };
                 ui.label(egui::RichText::new(status_icon).color(status_color));
             });

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -41,12 +41,7 @@ pub fn show(app: &mut crate::app::DAQApp, ctx: &egui::Context) {
             ui.heading("Side bar");
             ui.separator();
 
-            // Theme toggle button
-            let theme_label = match app.theme_selection {
-                crate::app::ThemeSelection::Default => "🎨 Theme: Default",
-                crate::app::ThemeSelection::Nord => "🎨 Theme: Nord",
-                crate::app::ThemeSelection::Catppuccin => "🎨 Theme: Catppuccin",
-            };
+            let theme_label = format!("🎨 Theme: {}", app.theme_selection.to_name());
 
             if ui.button(theme_label).clicked() {
                 app.toggle_theme();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -40,7 +40,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
             ui.heading("Side bar");
             ui.separator();
 
-            let theme_label = format!("🎨 Theme: {}", app.theme_selection.to_name());
+            let theme_label = format!("🎨 Theme: {}", app.theme_selection.get_name());
 
             if ui.button(theme_label).clicked() {
                 app.toggle_theme();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -9,7 +9,7 @@ pub fn select_dbc(
         .add_filter("DBC Files", &["dbc"])
         .pick_file()
     {
-        app.dbc_path = Some(path.clone());
+        app.parser = Some(app::ParserInfo::new(path.clone()));
         ui_sender
             .send(ui::ui_messages::UiMessage::DbcSelected(path))
             .expect("Failed to send DBC selected message");
@@ -100,10 +100,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                     select_dbc(app, &ui_sender); // mutable borrow is fine
                 }
 
-                // Clone the path for reading only
-                let dbc_path = app.dbc_path.clone();
-
-                if let Some(path) = dbc_path {
+                if let Some(path) = app.parser.as_ref().map(|p| &p.dbc_path) {
                     let dbc_name = path
                         .file_name()
                         .map(|n| n.to_string_lossy())

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,6 +1,5 @@
-use crate::{app, ui};
+use crate::{app, ui, util};
 use eframe::egui;
-use serialport::available_ports;
 
 pub fn select_dbc(
     app: &mut app::DAQApp,
@@ -86,24 +85,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                         }
                     });
                 if ui.button("🔄").clicked() {
-                    app.serial_ports = match available_ports() {
-                        Ok(ports) => ports
-                            .into_iter()
-                            .filter(|p| {
-                                let name = p.port_name.to_lowercase();
-                                if cfg!(target_os = "windows") {
-                                    name.starts_with("com")
-                                } else {
-                                    name.starts_with("/dev/tty.usbmodem")
-                                        || name.starts_with("/dev/ttyacm")
-                                }
-                            })
-                            .collect(),
-                        Err(err) => {
-                            log::error!("Failed to get ports: {err}");
-                            vec![]
-                        }
-                    };
+                    app.serial_ports = util::get_avaible_serial_ports();
                 }
             });
             if let Some(ref err) = app.connection_error {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,9 +1,9 @@
-use crate::ui::{self};
+use crate::{app, ui};
 use eframe::egui;
 use serialport::available_ports;
 
 pub fn select_dbc(
-    app: &mut crate::app::DAQApp,
+    app: &mut app::DAQApp,
     ui_sender: &std::sync::mpsc::Sender<ui::ui_messages::UiMessage>,
 ) {
     if let Some(path) = rfd::FileDialog::new()
@@ -18,7 +18,7 @@ pub fn select_dbc(
     }
 }
 
-pub fn show(app: &mut crate::app::DAQApp, ctx: &egui::Context) {
+pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
     let rounding = if cfg!(target_os = "macos") {
         egui::CornerRadius {
             nw: 12,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,4 +1,4 @@
-use crate::{app, ui, util};
+use crate::{action, app, ui, util};
 use eframe::egui;
 
 pub fn select_dbc(
@@ -50,19 +50,27 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
             ui.separator();
 
             if ui.button("Add CAN Viewer Table").clicked() {
-                app.spawn_viewer_table();
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    action::WidgetType::ViewerTable,
+                ));
             }
 
             if ui.button("Add CAN Viewer List").clicked() {
-                app.spawn_viewer_list();
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    action::WidgetType::ViewerList,
+                ));
             }
 
             if ui.button("Add Bootloader").clicked() {
-                app.spawn_bootloader();
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    action::WidgetType::Bootloader,
+                ));
             }
 
             if ui.button("Add Log Parser").clicked() {
-                app.spawn_log_parser();
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    action::WidgetType::LogParser,
+                ));
             }
             ui.horizontal(|ui| {
                 egui::ComboBox::from_label("Serial Port")

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -140,16 +140,12 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
             ui.horizontal(|ui| {
                 // Connection status indicator
                 let (status_icon, status_color) = match &app.connection_status {
-                    app::ConnectionStatus::Disconnected => ("⚪", egui::Color32::GRAY),
-                    app::ConnectionStatus::Connected => ("🟢", egui::Color32::GREEN),
-                    app::ConnectionStatus::Error(_) => ("🔴", egui::Color32::RED),
+                    app::ConnectionStatus::Disconnected => ("⚪ Disconnected".to_string(), egui::Color32::GRAY),
+                    app::ConnectionStatus::Connected => ("🟢 Connected".to_string(), egui::Color32::GREEN),
+                    app::ConnectionStatus::Error(e) => (format!("🔴 Error: {}", e), egui::Color32::RED),
                 };
                 ui.label(egui::RichText::new(status_icon).color(status_color));
             });
-
-            if let app::ConnectionStatus::Error(ref err) = app.connection_status {
-                ui.colored_label(egui::Color32::RED, format!(" {err}"));
-            }
 
             ui.horizontal(|ui| {
                 // Clone the sender so we don’t borrow app immutably yet

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -133,7 +133,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                     });
 
                 if ui.button("🔄").clicked() {
-                    app.serial_ports = util::get_avaible_serial_ports();
+                    app.serial_ports = util::get_available_serial_ports();
                 }
             });
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,4 +1,4 @@
-use crate::{action, app, ui, util};
+use crate::{action, app, connection, ui, util};
 use eframe::egui;
 
 pub fn select_dbc(
@@ -72,31 +72,82 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                     action::WidgetType::LogParser,
                 ));
             }
+
+            ui.separator();
+            ui.heading("Connection Settings");
+
             ui.horizontal(|ui| {
-                egui::ComboBox::from_label("Serial Port")
-                    .selected_text(app.selected_serial.as_deref().unwrap_or("Serial Port"))
+                ui.label("UDP Port:");
+                if ui
+                    .add(egui::DragValue::new(&mut app.udp_port).range(1..=65535))
+                    .changed()
+                {
+                    app.save_settings();
+                }
+            });
+
+            ui.horizontal(|ui| {
+                let selected_text = match &app.selected_source {
+                    Some(connection::ConnectionSource::Serial(p)) => format!("Serial: {}", p),
+                    Some(connection::ConnectionSource::Udp(p)) => format!("UDP: {}", p),
+                    None => "Select Source".to_string(),
+                };
+
+                egui::ComboBox::from_label("Source")
+                    .selected_text(selected_text)
                     .show_ui(ui, |ui| {
-                        for port in &app.serial_ports {
-                            let response = ui.selectable_value(
-                                &mut app.selected_serial,
-                                Some(port.port_name.clone()),
-                                &port.port_name,
-                            );
-                            if response.changed() {
-                                app.ui_sender
-                                    .send(ui::ui_messages::UiMessage::SerialSelected(
-                                        port.port_name.clone(),
-                                    ))
-                                    .expect("Failed to send serial selected");
+                        ui.label("Serial Ports");
+                        let ports: Vec<_> = app
+                            .serial_ports
+                            .iter()
+                            .map(|p| p.port_name.clone())
+                            .collect();
+                        for port_name in ports {
+                            let source = connection::ConnectionSource::Serial(port_name.clone());
+                            if ui
+                                .selectable_value(
+                                    &mut app.selected_source,
+                                    Some(source.clone()),
+                                    &port_name,
+                                )
+                                .changed()
+                            {
+                                app.connect_can();
                                 app.save_settings();
                             }
                         }
+                        ui.separator();
+                        ui.label("Network");
+                        let udp_source = connection::ConnectionSource::Udp(app.udp_port);
+                        if ui
+                            .selectable_value(
+                                &mut app.selected_source,
+                                Some(udp_source.clone()),
+                                format!("UDP ({})", app.udp_port),
+                            )
+                            .changed()
+                        {
+                            app.connect_can();
+                            app.save_settings();
+                        }
                     });
+
                 if ui.button("🔄").clicked() {
                     app.serial_ports = util::get_avaible_serial_ports();
                 }
             });
-            if let Some(ref err) = app.connection_error {
+
+            ui.horizontal(|ui| {
+                // Connection status indicator
+                let (status_icon, status_color) = match &app.connection_status {
+                    app::ConnectionStatus::Disconnected => ("⚪", egui::Color32::GRAY),
+                    app::ConnectionStatus::Connected => ("🟢", egui::Color32::GREEN),
+                    app::ConnectionStatus::Error(_) => ("🔴", egui::Color32::RED),
+                };
+                ui.label(egui::RichText::new(status_icon).color(status_color));
+            });
+
+            if let app::ConnectionStatus::Error(ref err) = app.connection_status {
                 ui.colored_label(egui::Color32::RED, format!(" {err}"));
             }
 

--- a/src/ui/ui_messages.rs
+++ b/src/ui/ui_messages.rs
@@ -1,4 +1,6 @@
+use crate::connection;
+
 pub enum UiMessage {
     DbcSelected(std::path::PathBuf),
-    SerialSelected(String),
+    Connect(connection::ConnectionSource),
 }

--- a/src/ui/viewer_list.rs
+++ b/src/ui/viewer_list.rs
@@ -98,17 +98,14 @@ impl ViewerList {
     }
 
     pub fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
-        match msg {
-            can::can_messages::CanMessage::ParsedMessage(parsed_msg) => {
-                if self.paused {
-                    return;
-                }
-                while self.decoded_msgs.len() >= MAX_MESSAGES - 1 {
-                    self.decoded_msgs.pop_front();
-                }
-                self.decoded_msgs.push_back(parsed_msg.clone());
+        if let can::can_messages::CanMessage::ParsedMessage(parsed_msg) = msg {
+            if self.paused {
+                return;
             }
-            _ => {}
+            while self.decoded_msgs.len() >= MAX_MESSAGES - 1 {
+                self.decoded_msgs.pop_front();
+            }
+            self.decoded_msgs.push_back(parsed_msg.clone());
         }
     }
 }

--- a/src/ui/viewer_list.rs
+++ b/src/ui/viewer_list.rs
@@ -97,15 +97,15 @@ impl ViewerList {
         egui_tiles::UiResponse::None
     }
 
-    pub fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
-        if let can::can_messages::CanMessage::ParsedMessage(parsed_msg) = msg {
-            if self.paused {
-                return;
-            }
-            while self.decoded_msgs.len() >= MAX_MESSAGES - 1 {
-                self.decoded_msgs.pop_front();
-            }
-            self.decoded_msgs.push_back(parsed_msg.clone());
+    pub fn handle_can_message(&mut self, msg: &can::message::ParsedMessage) {
+        if self.paused {
+            return;
         }
+
+        while self.decoded_msgs.len() >= MAX_MESSAGES - 1 {
+            self.decoded_msgs.pop_front();
+        }
+
+        self.decoded_msgs.push_back(msg.clone());
     }
 }

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -143,8 +143,7 @@ impl ViewerTable {
     }
 
     pub fn handle_can_message(&mut self, msg: &can::message::ParsedMessage) {
-        self.decoded_msgs
-            .insert(msg.decoded.msg_id, msg.clone());
+        self.decoded_msgs.insert(msg.decoded.msg_id, msg.clone());
     }
 }
 

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -122,17 +122,18 @@ impl ViewerTable {
                             .map(|b| format!("{:02X}", b))
                             .collect::<Vec<_>>()
                             .join(" ");
-                        message_card(
-                            ui,
-                            &msg.decoded.name,
-                            msg.decoded.msg_id,
-                            msg.decoded.tx_node.as_str(),
-                            raw_bytes_str.as_str(),
-                            &msg.timestamp.format("%-I:%M:%S%.3f").to_string(),
-                            &signals,
-                            &self.search,
-                            pending_scope_spawns,
-                        );
+                        MessageCard {
+                            msg_name: &msg.decoded.name,
+                            msg_id: msg.decoded.msg_id,
+                            tx_node: &msg.decoded.tx_node,
+                            raw_bytes: &raw_bytes_str,
+                            timestamp: &msg.timestamp.format("%H:%M:%S:%3f").to_string(),
+                            signals,
+                            search: &self.search,
+                        }
+                        .ui(ui)
+                        .into_iter()
+                        .for_each(|spawn| pending_scope_spawns.push(spawn));
                         ui.add_space(8.0);
                     }
                 });
@@ -149,90 +150,113 @@ impl ViewerTable {
     }
 }
 
-fn message_card(
-    ui: &mut egui::Ui,
-    msg_name: &str,
+struct MessageCard<'a> {
+    msg_name: &'a str,
     msg_id: u32,
-    tx_node: &str,
-    raw_bytes: &str,
-    timestamp: &str,
-    signals: &[(&str, String)],
-    search: &str,
-    pending_scope_spawns: &mut Vec<(u32, String, String)>,
-) {
-    // Header (outside card)
-    ui.horizontal(|ui| {
-        ui.label(
-            egui::RichText::new(format!("{}  (0x{:03X})", msg_name, msg_id))
-                .strong()
-                .size(16.0)
-                .color(
-                    if search.is_empty() || msg_name.to_lowercase().contains(&search.to_lowercase())
+    tx_node: &'a str,
+    raw_bytes: &'a str,
+    timestamp: &'a str,
+    signals: Vec<(&'a str, String)>,
+    search: &'a str,
+}
+
+impl MessageCard<'_> {
+    fn ui(&self, ui: &mut egui::Ui) -> Vec<(u32, String, String)> {
+        let mut pending_scope_spawns = Vec::new();
+        // Header (outside card)
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new(format!("{}  (0x{:03X})", self.msg_name, self.msg_id))
+                    .strong()
+                    .size(16.0)
+                    .color(
+                        if self.search.is_empty()
+                            || self
+                                .msg_name
+                                .to_lowercase()
+                                .contains(&self.search.to_lowercase())
+                        {
+                            ui.visuals().text_color()
+                        } else {
+                            ui.visuals().weak_text_color()
+                        },
+                    ),
+            );
+            ui.label(
+                egui::RichText::new(format!("from {}", self.tx_node)).color(
+                    if self.search.is_empty()
+                        || self
+                            .tx_node
+                            .to_lowercase()
+                            .contains(&self.search.to_lowercase())
                     {
                         ui.visuals().text_color()
                     } else {
                         ui.visuals().weak_text_color()
                     },
                 ),
-        );
-        ui.label(egui::RichText::new(format!("from {}", tx_node)).color(
-            if search.is_empty() || tx_node.to_lowercase().contains(&search.to_lowercase()) {
-                ui.visuals().text_color()
-            } else {
-                ui.visuals().weak_text_color()
-            },
-        ));
-        ui.label(
-            egui::RichText::new(timestamp)
-                .italics()
-                .color(ui.visuals().weak_text_color()),
-        );
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            ui.label(
-                egui::RichText::new(raw_bytes)
-                    .monospace()
-                    .color(ui.visuals().text_color()),
             );
-            ui.add_space(2.0);
-        });
-    });
-
-    ui.add_space(4.0);
-
-    // Card container
-    egui::Frame::group(ui.style())
-        .fill(ui.visuals().faint_bg_color)
-        .corner_radius(egui::CornerRadius::same(8))
-        .inner_margin(egui::Margin::symmetric(8, 6))
-        .show(ui, |ui| {
-            ui.vertical(|ui| {
-                for (i, (sig_name, value)) in signals.iter().enumerate() {
-                    ui.horizontal(|ui| {
-                        ui.label(egui::RichText::new(*sig_name).monospace().color(
-                            if search.is_empty()
-                                || sig_name.to_lowercase().contains(&search.to_lowercase())
-                            {
-                                ui.visuals().text_color()
-                            } else {
-                                ui.visuals().weak_text_color()
-                            },
-                        ));
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if ui.small_button("📊").clicked() {
-                                pending_scope_spawns.push((
-                                    msg_id,
-                                    msg_name.to_string(),
-                                    sig_name.to_string(),
-                                ));
-                            }
-                            ui.add_space(8.0);
-                            ui.label(egui::RichText::new(value).monospace());
-                        });
-                    });
-                    if i < signals.len() - 1 {
-                        ui.separator();
-                    }
-                }
+            ui.label(
+                egui::RichText::new(self.timestamp)
+                    .italics()
+                    .color(ui.visuals().weak_text_color()),
+            );
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.label(
+                    egui::RichText::new(self.raw_bytes)
+                        .monospace()
+                        .color(ui.visuals().text_color()),
+                );
+                ui.add_space(2.0);
             });
         });
+
+        ui.add_space(4.0);
+
+        // Card container
+        egui::Frame::group(ui.style())
+            .fill(ui.visuals().faint_bg_color)
+            .corner_radius(egui::CornerRadius::same(8))
+            .inner_margin(egui::Margin::symmetric(8, 6))
+            .show(ui, |ui| {
+                ui.vertical(|ui| {
+                    for (i, (sig_name, value)) in self.signals.iter().enumerate() {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(*sig_name).monospace().color(
+                                    if self.search.is_empty()
+                                        || sig_name
+                                            .to_lowercase()
+                                            .contains(&self.search.to_lowercase())
+                                    {
+                                        ui.visuals().text_color()
+                                    } else {
+                                        ui.visuals().weak_text_color()
+                                    },
+                                ),
+                            );
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if ui.small_button("📊").clicked() {
+                                        pending_scope_spawns.push((
+                                            self.msg_id,
+                                            self.msg_name.to_string(),
+                                            sig_name.to_string(),
+                                        ));
+                                    }
+                                    ui.add_space(8.0);
+                                    ui.label(egui::RichText::new(value).monospace());
+                                },
+                            );
+                        });
+                        if i < self.signals.len() - 1 {
+                            ui.separator();
+                        }
+                    }
+                });
+            });
+
+        pending_scope_spawns
+    }
 }

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -142,12 +142,9 @@ impl ViewerTable {
     }
 
     pub fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
-        match msg {
-            can::can_messages::CanMessage::ParsedMessage(parsed_msg) => {
-                self.decoded_msgs
-                    .insert(parsed_msg.decoded.msg_id, parsed_msg.clone());
-            }
-            _ => {}
+        if let can::can_messages::CanMessage::ParsedMessage(parsed_msg) = msg {
+            self.decoded_msgs
+                .insert(parsed_msg.decoded.msg_id, parsed_msg.clone());
         }
     }
 }

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -142,11 +142,9 @@ impl ViewerTable {
         egui_tiles::UiResponse::None
     }
 
-    pub fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
-        if let can::can_messages::CanMessage::ParsedMessage(parsed_msg) = msg {
-            self.decoded_msgs
-                .insert(parsed_msg.decoded.msg_id, parsed_msg.clone());
-        }
+    pub fn handle_can_message(&mut self, msg: &can::message::ParsedMessage) {
+        self.decoded_msgs
+            .insert(msg.decoded.msg_id, msg.clone());
     }
 }
 

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -1,4 +1,4 @@
-use crate::can;
+use crate::{action, can};
 use eframe::egui;
 use hashbrown::HashMap;
 
@@ -24,7 +24,7 @@ impl ViewerTable {
     pub fn show(
         &mut self,
         ui: &mut egui::Ui,
-        pending_scope_spawns: &mut Vec<(u32, String, String)>,
+        action_queue: &mut Vec<action::AppAction>,
     ) -> egui_tiles::UiResponse {
         ui.heading(format!("🚗 {}", self.title));
         if ui
@@ -133,7 +133,7 @@ impl ViewerTable {
                         }
                         .ui(ui)
                         .into_iter()
-                        .for_each(|spawn| pending_scope_spawns.push(spawn));
+                        .for_each(|spawn| action_queue.push(spawn));
                         ui.add_space(8.0);
                     }
                 });
@@ -161,8 +161,8 @@ struct MessageCard<'a> {
 }
 
 impl MessageCard<'_> {
-    fn ui(&self, ui: &mut egui::Ui) -> Vec<(u32, String, String)> {
-        let mut pending_scope_spawns = Vec::new();
+    fn ui(&self, ui: &mut egui::Ui) -> Vec<action::AppAction> {
+        let mut action_queue = Vec::new();
         // Header (outside card)
         ui.horizontal(|ui| {
             ui.label(
@@ -239,10 +239,12 @@ impl MessageCard<'_> {
                                 egui::Layout::right_to_left(egui::Align::Center),
                                 |ui| {
                                     if ui.small_button("📊").clicked() {
-                                        pending_scope_spawns.push((
-                                            self.msg_id,
-                                            self.msg_name.to_string(),
-                                            sig_name.to_string(),
+                                        action_queue.push(action::AppAction::SpawnWidget(
+                                            action::WidgetType::Scope {
+                                                msg_id: self.msg_id,
+                                                msg_name: self.msg_name.to_string(),
+                                                signal_name: sig_name.to_string(),
+                                            },
                                         ));
                                     }
                                     ui.add_space(8.0);
@@ -257,6 +259,6 @@ impl MessageCard<'_> {
                 });
             });
 
-        pending_scope_spawns
+        action_queue
     }
 }

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -127,7 +127,7 @@ impl ViewerTable {
                             msg_id: msg.decoded.msg_id,
                             tx_node: &msg.decoded.tx_node,
                             raw_bytes: &raw_bytes_str,
-                            timestamp: &msg.timestamp.format("%H:%M:%S:%3f").to_string(),
+                            timestamp: &msg.timestamp.format("%-I:%M:%S%.3f").to_string(),
                             signals,
                             search: &self.search,
                         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,18 @@
+pub fn get_avaible_serial_ports() -> Vec<serialport::SerialPortInfo> {
+    match serialport::available_ports() {
+        Ok(ports) => ports
+            .into_iter()
+            .filter(|p| {
+                let name = p.port_name.to_lowercase();
+                if cfg!(target_os = "windows") {
+                    name.starts_with("com")
+                } else {
+                    name.starts_with("/dev/tty.usbmodem") || name.starts_with("/dev/ttyacm")
+                }
+            })
+            .collect(),
+        Err(err) => {
+            panic!("Failed to get serial ports: {err}");
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,8 @@ pub fn get_available_serial_ports() -> Vec<serialport::SerialPortInfo> {
             })
             .collect(),
         Err(err) => {
-            panic!("Failed to get serial ports: {err}");
+            log::error!("Error listing serial ports: {}", err);
+            Vec::new()
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-pub fn get_avaible_serial_ports() -> Vec<serialport::SerialPortInfo> {
+pub fn get_available_serial_ports() -> Vec<serialport::SerialPortInfo> {
     match serialport::available_ports() {
         Ok(ports) => ports
             .into_iter()

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -30,7 +30,7 @@ impl Widget {
         let mut received_new_data = false;
 
         for msg in can_messages {
-            self.handle_can_message(&msg);
+            self.handle_can_message(msg);
             received_new_data = true;
         }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,4 +1,4 @@
-use crate::{app, can, ui};
+use crate::{action, app, can, ui};
 use eframe::egui;
 
 pub enum Widget {
@@ -24,7 +24,7 @@ impl Widget {
         &mut self,
         ui: &mut egui::Ui,
         can_messages: &[can::can_messages::CanMessage],
-        pending_scope_spawns: &mut Vec<(u32, String, String)>,
+        action_queue: &mut Vec<action::AppAction>,
         parser: Option<&app::ParserInfo>,
     ) -> egui_tiles::UiResponse {
         let mut received_new_data = false;
@@ -40,7 +40,7 @@ impl Widget {
         }
 
         match self {
-            Widget::ViewerTable(w) => w.show(ui, pending_scope_spawns),
+            Widget::ViewerTable(w) => w.show(ui, action_queue),
             Widget::ViewerList(w) => w.show(ui),
             Widget::Bootloader(w) => w.show(ui),
             Widget::Scope(w) => w.show(ui),

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -23,7 +23,7 @@ impl Widget {
     pub fn show(
         &mut self,
         ui: &mut egui::Ui,
-        can_messages: &[can::can_messages::CanMessage],
+        can_messages: &[can::message::ParsedMessage],
         action_queue: &mut Vec<action::AppAction>,
         parser: Option<&app::ParserInfo>,
     ) -> egui_tiles::UiResponse {
@@ -48,7 +48,7 @@ impl Widget {
         }
     }
 
-    fn handle_can_message(&mut self, msg: &can::can_messages::CanMessage) {
+    fn handle_can_message(&mut self, msg: &can::message::ParsedMessage) {
         match self {
             Widget::ViewerTable(w) => w.handle_can_message(msg),
             Widget::ViewerList(w) => w.handle_can_message(msg),

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,7 +1,4 @@
-use crate::{
-    can::{self, can_messages},
-    ui,
-};
+use crate::{app, can, ui};
 use eframe::egui;
 
 pub enum Widget {
@@ -28,7 +25,7 @@ impl Widget {
         ui: &mut egui::Ui,
         can_messages: &[can::can_messages::CanMessage],
         pending_scope_spawns: &mut Vec<(u32, String, String)>,
-        dbc_path: Option<&std::path::PathBuf>,
+        parser: Option<&app::ParserInfo>,
     ) -> egui_tiles::UiResponse {
         let mut received_new_data = false;
 
@@ -47,7 +44,7 @@ impl Widget {
             Widget::ViewerList(w) => w.show(ui),
             Widget::Bootloader(w) => w.show(ui),
             Widget::Scope(w) => w.show(ui),
-            Widget::LogParser(w) => w.show(ui, dbc_path),
+            Widget::LogParser(w) => w.show(ui, parser),
         }
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,7 +1,7 @@
-use crate::{can, widgets};
+use crate::{app, can, widgets};
 use eframe::egui;
 
-pub fn show(app: &mut crate::app::DAQApp, ctx: &egui::Context) {
+pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
     let rounding = if cfg!(target_os = "macos") {
         egui::CornerRadius {
             nw: 0,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,4 @@
-use crate::{app, can, widgets};
+use crate::{action, app, can, widgets};
 use eframe::egui;
 
 pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
@@ -30,15 +30,14 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
             } else {
                 let mut behavior = WorkspaceTileBehavior {
                     can_messages: &app.can_messages,
-                    pending_scope_spawns: &mut app.pending_scope_spawns,
+                    action_queue: &mut app.action_queue,
                     parser: app.parser.as_ref(),
                 };
                 app.tile_tree.ui(&mut behavior, ui);
 
                 // Spawn all pending scopes in the queue
-                for (msg_id, msg_name, signal_name) in std::mem::take(&mut app.pending_scope_spawns)
-                {
-                    app.spawn_scope(msg_id, msg_name, signal_name);
+                for action in std::mem::take(&mut app.action_queue) {
+                    app.handle_action(action);
                 }
             }
         });
@@ -46,7 +45,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
 
 struct WorkspaceTileBehavior<'a> {
     can_messages: &'a [can::can_messages::CanMessage],
-    pending_scope_spawns: &'a mut Vec<(u32, String, String)>,
+    action_queue: &'a mut Vec<action::AppAction>,
     parser: Option<&'a app::ParserInfo>,
 }
 
@@ -57,12 +56,7 @@ impl egui_tiles::Behavior<widgets::Widget> for WorkspaceTileBehavior<'_> {
         _tile_id: egui_tiles::TileId,
         widget: &mut widgets::Widget,
     ) -> egui_tiles::UiResponse {
-        widget.show(
-            ui,
-            self.can_messages,
-            self.pending_scope_spawns,
-            self.parser,
-        )
+        widget.show(ui, self.can_messages, self.action_queue, self.parser)
     }
 
     fn tab_title_for_pane(&mut self, widget: &widgets::Widget) -> egui::WidgetText {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -31,7 +31,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                 let mut behavior = WorkspaceTileBehavior {
                     can_messages: &app.can_messages,
                     pending_scope_spawns: &mut app.pending_scope_spawns,
-                    dbc_path: app.dbc_path.as_ref(),
+                    parser: app.parser.as_ref(),
                 };
                 app.tile_tree.ui(&mut behavior, ui);
 
@@ -47,7 +47,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
 struct WorkspaceTileBehavior<'a> {
     can_messages: &'a [can::can_messages::CanMessage],
     pending_scope_spawns: &'a mut Vec<(u32, String, String)>,
-    dbc_path: Option<&'a std::path::PathBuf>,
+    parser: Option<&'a app::ParserInfo>,
 }
 
 impl egui_tiles::Behavior<widgets::Widget> for WorkspaceTileBehavior<'_> {
@@ -61,7 +61,7 @@ impl egui_tiles::Behavior<widgets::Widget> for WorkspaceTileBehavior<'_> {
             ui,
             self.can_messages,
             self.pending_scope_spawns,
-            self.dbc_path,
+            self.parser,
         )
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -39,7 +39,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
 }
 
 struct WorkspaceTileBehavior<'a> {
-    can_messages: &'a [can::can_messages::CanMessage],
+    can_messages: &'a [can::message::ParsedMessage],
     action_queue: &'a mut Vec<action::AppAction>,
     parser: Option<&'a app::ParserInfo>,
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -34,11 +34,6 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                     parser: app.parser.as_ref(),
                 };
                 app.tile_tree.ui(&mut behavior, ui);
-
-                // Spawn all pending scopes in the queue
-                for action in std::mem::take(&mut app.action_queue) {
-                    app.handle_action(action);
-                }
             }
         });
 }


### PR DESCRIPTION
* Emotional successor to #35 
* Generally cleaning and small reorganization
* Preparing for an Ethernet/UDP backed can thread

> Refactors the app architecture to decouple UI widget spawning and CAN connectivity, while reorganizing settings/theme handling in preparation for future Ethernet/UDP-backed CAN support