### PR TITLE
Support for multiple CAN/DAQ frames in 1 UDP packet

### DIFF
--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -220,7 +220,7 @@ impl SimulatedDriver {
 }
 
 impl Driver for SimulatedDriver {
-    fn read_frame(&mut self) -> DriverResult<CanFrame> {
+    fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>> {
         if self.connected {
             let mut rng = rand::rng();
 
@@ -246,7 +246,7 @@ impl Driver for SimulatedDriver {
                 };
                 let can_frame = slcan::Can2Frame::new_data(id, &data)
                     .expect("failed to create CAN frame from random data");
-                Ok(can_frame.into())
+                Ok(vec![can_frame.into()])
             } else {
                 // If no DBC is loaded, just return random frames with random IDs and data
                 let id = rng.random_range(0..=util::msg_id::STANDARD_ID_MASK) as u16;
@@ -255,7 +255,7 @@ impl Driver for SimulatedDriver {
                 rng.fill_bytes(&mut data);
                 let can2 = slcan::Can2Frame::new_data(sid, &data)
                     .expect("failed to create CAN frame from random data");
-                Ok(can2.into())
+                Ok(vec![can2.into()])
             }
         } else {
             Err(DriverError::ReadError(DriverReadError::Other(

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -301,7 +301,7 @@ pub fn parse_udp_buffer(
         );
     }
 
-    let mut frames = Vec::new();
+    let mut frames = Vec::with_capacity(num_bytes / UDP_RAW_FRAME_SIZE);
     let mask_id = (1u32 << 29) - 1;
 
     // TODO: use the daq_parse way with bytemuck?

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -131,9 +131,7 @@ pub struct UdpDriver {
 }
 
 impl UdpDriver {
-    /// Create a new UDP driver
     pub fn new(port: u16) -> DriverResult<Self> {
-        // TODO: Implement UDP connection
         let udp_addr = format!("0.0.0.0:{}", port);
         let socket = UdpSocket::bind(udp_addr).map_err(|e| {
             DriverError::ConnectionFailed(format!("Failed to bind to port {}: {}", port, e))
@@ -162,7 +160,6 @@ impl Driver for UdpDriver {
     fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>> {
         let mut buf = [0; UDP_MAX_PACKET_SIZE];
         match self.socket.recv_from(&mut buf) {
-            Ok((num_bytes, _src_port)) => {
                 // TODO: parse buffer into one or more CanFrame(s) per your protocol.
                 parse_udp_buffer(&buf, num_bytes)
             }
@@ -185,7 +182,7 @@ impl Driver for UdpDriver {
     }
 
     fn write_frame(&mut self, _frame: CanFrame) -> DriverResult<()> {
-        log::error!("UDP write requested but not implemented; ignoring frame.");
+        log::error!("UDP write requested but not supported; ignoring frame.");
         Ok(())
     }
 
@@ -300,6 +297,9 @@ pub fn parse_udp_buffer(
             UDP_RAW_FRAME_SIZE
         );
     }
+
+    let x = num_bytes / UDP_RAW_FRAME_SIZE;
+    println!("Parsing UDP frame: {num_bytes} ({x})");
 
     let mut frames = Vec::with_capacity(num_bytes / UDP_RAW_FRAME_SIZE);
     let mask_id = (1u32 << 29) - 1;

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -10,6 +10,9 @@ use std::time::Duration;
 const SERIAL_BAUD_RATE: u32 = 115_200;
 const SERIAL_TIMEOUT_MS: u64 = 10;
 
+const UDP_RAW_FRAME_SIZE: usize = 16; // 4 bytes ticks_ms + 4 bytes identity + 8 bytes payload
+const UDP_MAX_PACKET_SIZE: usize = 2048;
+
 pub type DriverResult<T> = Result<T, DriverError>;
 
 #[derive(Debug)]
@@ -27,7 +30,7 @@ pub enum DriverError {
 }
 
 pub trait Driver {
-    fn read_frame(&mut self) -> DriverResult<CanFrame>;
+    fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>>;
 
     fn write_frame(&mut self, frame: CanFrame) -> DriverResult<()>;
 
@@ -72,26 +75,32 @@ impl SerialDriver {
 }
 
 impl Driver for SerialDriver {
-    fn read_frame(&mut self) -> DriverResult<CanFrame> {
-        self.socket.read().map_err(|e| match e {
-            slcan::ReadError::Io(io_err) => {
-                if io_err.kind() == std::io::ErrorKind::WouldBlock
-                    || io_err.kind() == std::io::ErrorKind::TimedOut
-                {
-                    DriverError::ReadError(DriverReadError::Timeout)
-                } else {
+    fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>> {
+        self.socket
+            .read()
+            .map_err(|e| match e {
+                slcan::ReadError::Io(io_err) => {
+                    if io_err.kind() == std::io::ErrorKind::WouldBlock
+                        || io_err.kind() == std::io::ErrorKind::TimedOut
+                    {
+                        DriverError::ReadError(DriverReadError::Timeout)
+                    } else {
+                        self.connected = false;
+                        DriverError::ReadError(DriverReadError::IoError(format!(
+                            "I/O error: {}",
+                            io_err
+                        )))
+                    }
+                }
+                other => {
                     self.connected = false;
-                    DriverError::ReadError(DriverReadError::IoError(format!(
-                        "I/O error: {}",
-                        io_err
+                    DriverError::ReadError(DriverReadError::Other(format!(
+                        "Read error: {:?}",
+                        other
                     )))
                 }
-            }
-            other => {
-                self.connected = false;
-                DriverError::ReadError(DriverReadError::Other(format!("Read error: {:?}", other)))
-            }
-        })
+            })
+            .map(|frame| vec![frame]) // wrap single frame in a vector for consistency with UDP driver
     }
 
     fn write_frame(&mut self, frame: CanFrame) -> DriverResult<()> {
@@ -152,14 +161,12 @@ impl UdpDriver {
 }
 
 impl Driver for UdpDriver {
-    fn read_frame(&mut self) -> DriverResult<CanFrame> {
-        // TODO: possibly need to handle the the fact that one UDP packet could contain multiple CAN frames
-
+    fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>> {
         log::info!("Trying to read UDP frame...");
         // and the data is in PER DAQ log format, not raw CAN frames
-        let mut buf = [0; 2048];
+        let mut buf = [0; UDP_MAX_PACKET_SIZE];
         match self.socket.recv_from(&mut buf) {
-            Ok((num_bytes, src_port)) => {
+            Ok((num_bytes, _src_port)) => {
                 // TODO: parse buffer into one or more CanFrame(s) per your protocol.
                 log::info!("Recieved byte buf");
                 parse_udp_buffer(&buf, num_bytes)
@@ -282,41 +289,58 @@ impl Driver for SimulatedDriver {
     }
 }
 
-pub fn parse_udp_buffer(buf: &[u8; 2048], num_bytes: usize) -> DriverResult<CanFrame> {
-    if num_bytes < 5 {
+pub fn parse_udp_buffer(
+    buf: &[u8; UDP_MAX_PACKET_SIZE],
+    num_bytes: usize,
+) -> DriverResult<Vec<CanFrame>> {
+    if num_bytes < UDP_RAW_FRAME_SIZE {
         return Err(DriverError::ReadError(DriverReadError::Other(format!(
-            " Received packet too small: {} bytes",
+            "Received packet too small: {} bytes",
             num_bytes
         ))));
+    } else if num_bytes % UDP_RAW_FRAME_SIZE != 0 {
+        log::warn!(
+            "Received packet of size {} which is not a multiple of raw frame size {}; some data may be ignored",
+            num_bytes,
+            UDP_RAW_FRAME_SIZE
+        );
     }
 
-    log::info!("Parsing UDP packet");
-    // parse can frame from UDP packet according to new timestamped frame format
-    // format: [4 bytes ticks_ms] [4 bytes identity] [8 bytes payload]
-    // identity format: [1 bit bus ID] [1 bit isExtID] [1 bit reserved] [29 bits CAN ID]
-    // (definitions from spmc.h)
-    let identity = u32::from_le_bytes(buf[4..8].try_into().unwrap());
-    let payload = &buf[8..16];
+    let mut frames = Vec::new();
     let mask_id = (1u32 << 29) - 1;
-    let id = identity & mask_id;
-    if id <= util::msg_id::STANDARD_ID_MASK {
-        let sid = slcan::StandardId::new(id as u16).ok_or_else(|| {
-            DriverError::ReadError(DriverReadError::Other("invalid standard id".into()))
-        })?;
-        let can2 = slcan::Can2Frame::new_data(sid, payload).ok_or_else(|| {
-            DriverError::ReadError(DriverReadError::Other("invalid CAN2 data".into()))
-        })?;
-        Ok(can2.into())
-    } else {
-        //extid
-        let eid = slcan::ExtendedId::new(id).ok_or_else(|| {
-            DriverError::ReadError(DriverReadError::Other("invalid extended id".into()))
-        })?;
-        let can2 = slcan::Can2Frame::new_data(eid, payload).ok_or_else(|| {
-            DriverError::ReadError(DriverReadError::Other("invalid CAN2 data".into()))
-        })?;
-        Ok(can2.into())
+    // TODO: use the daq_parse way with bytemuck?
+    for chunk in buf[..num_bytes].chunks_exact(UDP_RAW_FRAME_SIZE) {
+        let identity = u32::from_le_bytes(chunk[4..8].try_into().unwrap());
+        let payload = &chunk[8..16];
+
+        let id = identity & mask_id;
+
+        let frame = if id <= 0x7FF {
+            let sid = slcan::StandardId::new(id as u16).ok_or_else(|| {
+                DriverError::ReadError(DriverReadError::Other("invalid standard id".into()))
+            })?;
+
+            let can2 = slcan::Can2Frame::new_data(sid, payload).ok_or_else(|| {
+                DriverError::ReadError(DriverReadError::Other("invalid CAN2 data".into()))
+            })?;
+
+            can2.into()
+        } else {
+            let eid = slcan::ExtendedId::new(id).ok_or_else(|| {
+                DriverError::ReadError(DriverReadError::Other("invalid extended id".into()))
+            })?;
+
+            let can2 = slcan::Can2Frame::new_data(eid, payload).ok_or_else(|| {
+                DriverError::ReadError(DriverReadError::Other("invalid CAN2 data".into()))
+            })?;
+
+            can2.into()
+        };
+
+        frames.push(frame);
     }
+
+    Ok(frames)
 }
 
 pub fn create_driver(source: &ConnectionSource) -> DriverResult<Box<dyn Driver>> {

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -166,7 +166,6 @@ impl Driver for UdpDriver {
                 if e.kind() == std::io::ErrorKind::WouldBlock
                     || e.kind() == std::io::ErrorKind::TimedOut
                 {
-                    std::thread::sleep(Duration::from_millis(10));
                     Err(DriverError::ReadError(DriverReadError::Timeout))
                 } else {
                     self.connected = false;

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -149,8 +149,6 @@ impl UdpDriver {
             .map_err(|e| {
                 DriverError::ConnectionFailed(format!("Failed to set read timeout: {}", e))
             })?;
-        log::info!("Socket local addr: {:?}", socket.local_addr());
-        log::info!("Socket read timeout: {:?}", socket.read_timeout());
 
         Ok(Self {
             port,
@@ -162,13 +160,10 @@ impl UdpDriver {
 
 impl Driver for UdpDriver {
     fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>> {
-        log::info!("Trying to read UDP frame...");
-        // and the data is in PER DAQ log format, not raw CAN frames
         let mut buf = [0; UDP_MAX_PACKET_SIZE];
         match self.socket.recv_from(&mut buf) {
             Ok((num_bytes, _src_port)) => {
                 // TODO: parse buffer into one or more CanFrame(s) per your protocol.
-                log::info!("Recieved byte buf");
                 parse_udp_buffer(&buf, num_bytes)
             }
             Err(e) => {
@@ -312,6 +307,10 @@ pub fn parse_udp_buffer(
     // TODO: use the daq_parse way with bytemuck?
     let mut chunks = buf[..num_bytes].chunks_exact(UDP_RAW_FRAME_SIZE);
     for chunk in &mut chunks {
+        // Parse can frame from UDP packet according to new timestamped frame format
+        // Format: [4 bytes ticks_ms] [4 bytes identity] [8 bytes payload]
+        // Identity format: [1 bit bus ID] [1 bit isExtID] [1 bit reserved] [29 bits CAN ID]
+        // (definitions from spmc.h)
         let identity = u32::from_le_bytes(chunk[4..8].try_into().unwrap());
         let payload = &chunk[8..16];
 

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -160,9 +160,7 @@ impl Driver for UdpDriver {
     fn read_frames(&mut self) -> DriverResult<Vec<CanFrame>> {
         let mut buf = [0; UDP_MAX_PACKET_SIZE];
         match self.socket.recv_from(&mut buf) {
-                // TODO: parse buffer into one or more CanFrame(s) per your protocol.
-                parse_udp_buffer(&buf, num_bytes)
-            }
+            Ok((num_bytes, _src_port)) => parse_udp_buffer(&buf, num_bytes),
             Err(e) => {
                 log::warn!("{}", e);
                 if e.kind() == std::io::ErrorKind::WouldBlock

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -308,8 +308,10 @@ pub fn parse_udp_buffer(
 
     let mut frames = Vec::new();
     let mask_id = (1u32 << 29) - 1;
+
     // TODO: use the daq_parse way with bytemuck?
-    for chunk in buf[..num_bytes].chunks_exact(UDP_RAW_FRAME_SIZE) {
+    let mut chunks = buf[..num_bytes].chunks_exact(UDP_RAW_FRAME_SIZE);
+    for chunk in &mut chunks {
         let identity = u32::from_le_bytes(chunk[4..8].try_into().unwrap());
         let payload = &chunk[8..16];
 
@@ -338,6 +340,14 @@ pub fn parse_udp_buffer(
         };
 
         frames.push(frame);
+    }
+
+    let remainder = chunks.remainder();
+    if !remainder.is_empty() {
+        log::warn!(
+            "UDP packet had {} extra bytes (not a full CAN frame)",
+            remainder.len()
+        );
     }
 
     Ok(frames)

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -207,11 +207,12 @@ pub fn start_can_thread(
                 continue;
             };
 
-            match active_driver.read_frame() {
-                Ok(frame) => {
-                    let data_bytes = process_can_frame(frame, &state);
-                    state.bus_load_tracker.record_frame(data_bytes);
-
+            match active_driver.read_frames() {
+                Ok(frames) => {
+                    for frame in frames {
+                        let data_bytes = process_can_frame(frame, &state);
+                        state.bus_load_tracker.record_frame(data_bytes);
+                    }
                     // Send bus load updates periodically
                     if state.last_bus_load_update.elapsed().as_millis() >= BUS_LOAD_UPDATE_MS {
                         state.bus_load_tracker.cleanup();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 use crate::{connection, theme};
 
 pub const SETTINGS_PATH: &str = "settings.json";
-const DEFAULT_UDP_PORT: u16 = 5000;
+const DEFAULT_UDP_PORT: u16 = 5005;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Settings {


### PR DESCRIPTION
* `trait Driver::read_frames` returns `DriverResult<Vec<CanFrame>>` instead of just one (`DriverResult<CanFrame>`) (and renamed accordingly)
* Implementing read frame for UDP (break read bytes into chunks, parse each chunk as a message)
* Serial just returns a vec of length 1