### PR TITLE
Bus load

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -19,6 +19,7 @@ pub enum WidgetType {
     },
     LogParser,
     SendUi,
+    BusLoad,
 }
 
 impl AppAction {
@@ -29,6 +30,7 @@ impl AppAction {
             ("Spawn Bootloader", WidgetType::Bootloader),
             ("Spawn Log Parser", WidgetType::LogParser),
             ("Spawn Send UI", WidgetType::SendUi),
+            ("Spawn Bus Load", WidgetType::BusLoad),
         ]
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,6 +43,7 @@ pub struct DAQApp {
     pub next_scope_num: usize,
     pub next_log_parser_num: usize,
     pub next_send_ui_num: usize,
+    pub next_bus_load_num: usize,
     pub can_to_ui_rx: std::sync::mpsc::Receiver<messages::MsgFromCan>,
     pub ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
     pub action_queue: Vec<action::AppAction>,
@@ -88,6 +89,7 @@ impl DAQApp {
             next_scope_num: 1,
             next_log_parser_num: 1,
             next_send_ui_num: 1,
+            next_bus_load_num: 1,
             can_to_ui_rx,
             ui_to_can_tx,
             action_queue: Vec::new(),
@@ -170,6 +172,9 @@ impl DAQApp {
                     action::WidgetType::SendUi => {
                         widgets::Widget::SendUi(ui::send::SendUi::new(self.next_send_ui_num))
                     }
+                    action::WidgetType::BusLoad => {
+                        widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.next_bus_load_num))
+                    }
                 };
                 self.add_widget_to_tree(widget);
 
@@ -192,6 +197,9 @@ impl DAQApp {
                     }
                     action::WidgetType::SendUi => {
                         self.next_send_ui_num += 1;
+                    }
+                    action::WidgetType::BusLoad => {
+                        self.next_bus_load_num += 1;
                     }
                 }
             }
@@ -255,7 +263,8 @@ impl eframe::App for DAQApp {
                     self.connection_status = ConnectionStatus::Disconnected;
                 }
                 messages::MsgFromCan::ParsedMessage(_)
-                | messages::MsgFromCan::MessageSent { .. } => {
+                | messages::MsgFromCan::MessageSent { .. }
+                | messages::MsgFromCan::BusLoad { .. } => {
                     // Nothing special to do here, the message will be handled
                     // in the individual widgets
                 }

--- a/src/can/bus_load.rs
+++ b/src/can/bus_load.rs
@@ -1,33 +1,20 @@
-const BUS_LOAD_BUCKET_MS: i64 = 25; // Group frames into 25ms buckets for load calculation
 const CAN_BUS_SPEED: f32 = 500_000.0; // 500 kbps
 const CAN_FRAME_BITS: usize = 130;
+const CLEAN_UP_INTERVAL_SECS: i64 = 30;
 
 pub struct BusLoadTracker {
-    pub timestamps: std::collections::VecDeque<chrono::DateTime<chrono::Local>>,
-    pub bits: std::collections::VecDeque<usize>,
+    timestamps: std::collections::VecDeque<chrono::DateTime<chrono::Local>>,
 }
 
 impl BusLoadTracker {
     pub fn new() -> Self {
         Self {
             timestamps: std::collections::VecDeque::new(),
-            bits: std::collections::VecDeque::new(),
         }
     }
 
     pub fn record_frame(&mut self) {
-        let now = chrono::Local::now();
-        if let Some(last_timestamp) = self.timestamps.back() {
-            if (now - *last_timestamp).num_milliseconds() < BUS_LOAD_BUCKET_MS {
-                // Same timing bucket, add to existing
-                if let Some(last_bits) = self.bits.back_mut() {
-                    *last_bits += CAN_FRAME_BITS;
-                }
-                return;
-            }
-        }
-        self.timestamps.push_back(now);
-        self.bits.push_back(CAN_FRAME_BITS);
+        self.timestamps.push_back(chrono::Local::now());
     }
 
     // Returns bus load percentage for the given window in seconds
@@ -36,12 +23,12 @@ impl BusLoadTracker {
         let window_duration = chrono::Duration::seconds(window_secs as i64);
         let cutoff_time = now - window_duration;
 
-        let mut total_bits = 0;
-        for (i, &ts) in self.timestamps.iter().enumerate() {
-            if ts > cutoff_time {
-                total_bits += self.bits[i];
-            }
-        }
+        let total_bits = self
+            .timestamps
+            .iter()
+            .filter(|&&ts| ts > cutoff_time)
+            .count()
+            * CAN_FRAME_BITS;
 
         let max_bits_in_window = CAN_BUS_SPEED * window_secs as f32;
         (total_bits as f32 / max_bits_in_window) * 100.0
@@ -49,11 +36,10 @@ impl BusLoadTracker {
 
     // Clean up old entries
     pub fn cleanup(&mut self) {
-        let cutoff_time = chrono::Local::now() - chrono::Duration::seconds(30);
+        let cutoff_time = chrono::Local::now() - chrono::Duration::seconds(CLEAN_UP_INTERVAL_SECS);
         while let Some(&ts) = self.timestamps.front() {
             if ts <= cutoff_time {
                 self.timestamps.pop_front();
-                self.bits.pop_front();
             } else {
                 break;
             }

--- a/src/can/bus_load.rs
+++ b/src/can/bus_load.rs
@@ -6,31 +6,31 @@ const CAN_BUS_SPEED: f32 = 500_000.0; // 500 kbps
 // IDE	1
 // r0	1
 // DLC	4
-// Data	64
 // CRC	15
 // CRC delim	1
 // ACK	2
 // EOF	7
 // IFS	3
-// Subtotal: 111
+// Subtotal: 47
 // But with bit stuffing: +~20%
-const CAN_FRAME_BITS: usize = 130;
+const CAN_FRAME_BASE_BITS: usize = 66;
 
 const CLEAN_UP_INTERVAL_SECS: i64 = 30;
 
 pub struct BusLoadTracker {
-    timestamps: std::collections::VecDeque<chrono::DateTime<chrono::Local>>,
+    timestamp_bits: std::collections::VecDeque<(chrono::DateTime<chrono::Local>, usize)>,
 }
 
 impl BusLoadTracker {
     pub fn new() -> Self {
         Self {
-            timestamps: std::collections::VecDeque::new(),
+            timestamp_bits: std::collections::VecDeque::new(),
         }
     }
 
-    pub fn record_frame(&mut self) {
-        self.timestamps.push_back(chrono::Local::now());
+    pub fn record_frame(&mut self, data_bytes: usize) {
+        self.timestamp_bits
+            .push_back((chrono::Local::now(), data_bytes * 8 + CAN_FRAME_BASE_BITS));
     }
 
     // Returns bus load percentage for the given window in seconds
@@ -39,12 +39,12 @@ impl BusLoadTracker {
         let window_duration = chrono::Duration::seconds(window_secs as i64);
         let cutoff_time = now - window_duration;
 
-        let total_bits = self
-            .timestamps
+        let total_bits: usize = self
+            .timestamp_bits
             .iter()
-            .filter(|&&ts| ts > cutoff_time)
-            .count()
-            * CAN_FRAME_BITS;
+            .filter(|&&(ts, _)| ts > cutoff_time)
+            .map(|&(_, bits)| bits)
+            .sum();
 
         let max_bits_in_window = CAN_BUS_SPEED * window_secs as f32;
         (total_bits as f32 / max_bits_in_window) * 100.0
@@ -53,9 +53,9 @@ impl BusLoadTracker {
     // Clean up old entries
     pub fn cleanup(&mut self) {
         let cutoff_time = chrono::Local::now() - chrono::Duration::seconds(CLEAN_UP_INTERVAL_SECS);
-        while let Some(&ts) = self.timestamps.front() {
+        while let Some(&(ts, _)) = self.timestamp_bits.front() {
             if ts <= cutoff_time {
-                self.timestamps.pop_front();
+                self.timestamp_bits.pop_front();
             } else {
                 break;
             }

--- a/src/can/bus_load.rs
+++ b/src/can/bus_load.rs
@@ -1,5 +1,21 @@
 const CAN_BUS_SPEED: f32 = 500_000.0; // 500 kbps
+
+// SOF	1
+// ID	11
+// RTR	1
+// IDE	1
+// r0	1
+// DLC	4
+// Data	64
+// CRC	15
+// CRC delim	1
+// ACK	2
+// EOF	7
+// IFS	3
+// Subtotal: 111
+// But with bit stuffing: +~20%
 const CAN_FRAME_BITS: usize = 130;
+
 const CLEAN_UP_INTERVAL_SECS: i64 = 30;
 
 pub struct BusLoadTracker {

--- a/src/can/bus_load.rs
+++ b/src/can/bus_load.rs
@@ -1,0 +1,62 @@
+const BUS_LOAD_BUCKET_MS: i64 = 25; // Group frames into 25ms buckets for load calculation
+const CAN_BUS_SPEED: f32 = 500_000.0; // 500 kbps
+const CAN_FRAME_BITS: usize = 130;
+
+pub struct BusLoadTracker {
+    pub timestamps: std::collections::VecDeque<chrono::DateTime<chrono::Local>>,
+    pub bits: std::collections::VecDeque<usize>,
+}
+
+impl BusLoadTracker {
+    pub fn new() -> Self {
+        Self {
+            timestamps: std::collections::VecDeque::new(),
+            bits: std::collections::VecDeque::new(),
+        }
+    }
+
+    pub fn record_frame(&mut self) {
+        let now = chrono::Local::now();
+        if let Some(last_timestamp) = self.timestamps.back() {
+            if (now - *last_timestamp).num_milliseconds() < BUS_LOAD_BUCKET_MS {
+                // Same timing bucket, add to existing
+                if let Some(last_bits) = self.bits.back_mut() {
+                    *last_bits += CAN_FRAME_BITS;
+                }
+                return;
+            }
+        }
+        self.timestamps.push_back(now);
+        self.bits.push_back(CAN_FRAME_BITS);
+    }
+
+    // Returns bus load percentage for the given window in seconds
+    pub fn get_load(&self, window_secs: u64) -> f32 {
+        let now = chrono::Local::now();
+        let window_duration = chrono::Duration::seconds(window_secs as i64);
+        let cutoff_time = now - window_duration;
+
+        let mut total_bits = 0;
+        for (i, &ts) in self.timestamps.iter().enumerate() {
+            if ts > cutoff_time {
+                total_bits += self.bits[i];
+            }
+        }
+
+        let max_bits_in_window = CAN_BUS_SPEED * window_secs as f32;
+        (total_bits as f32 / max_bits_in_window) * 100.0
+    }
+
+    // Clean up old entries
+    pub fn cleanup(&mut self) {
+        let cutoff_time = chrono::Local::now() - chrono::Duration::seconds(30);
+        while let Some(&ts) = self.timestamps.front() {
+            if ts <= cutoff_time {
+                self.timestamps.pop_front();
+                self.bits.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/src/can/mod.rs
+++ b/src/can/mod.rs
@@ -1,3 +1,4 @@
+pub mod bus_load;
 pub mod driver;
 pub mod state;
 pub mod thread;

--- a/src/can/state.rs
+++ b/src/can/state.rs
@@ -8,6 +8,8 @@ pub struct State {
     pub is_connected: bool,
     pub parser: Option<can_decode::Parser>,
     pub send_msgs: std::collections::HashMap<u32, SendMsgInfo>, // msg_id -> SendMsg
+    pub bus_load_tracker: can::bus_load::BusLoadTracker,
+    pub last_bus_load_update: std::time::Instant,
 }
 
 pub struct SendMsgInfo {
@@ -37,6 +39,8 @@ impl State {
             is_connected: false,
             parser: None,
             send_msgs: std::collections::HashMap::new(),
+            bus_load_tracker: can::bus_load::BusLoadTracker::new(),
+            last_bus_load_update: std::time::Instant::now(),
         }
     }
 

--- a/src/can/state.rs
+++ b/src/can/state.rs
@@ -1,8 +1,10 @@
-use crate::messages;
+use crate::{can, connection, messages};
 
 pub struct State {
     pub can_to_ui_tx: std::sync::mpsc::Sender<messages::MsgFromCan>,
     pub ui_to_can_rx: std::sync::mpsc::Receiver<messages::MsgFromUi>,
+    pub driver: Option<Box<dyn can::driver::Driver>>,
+    pub current_source: Option<connection::ConnectionSource>,
     pub is_connected: bool,
     pub parser: Option<can_decode::Parser>,
     pub send_msgs: std::collections::HashMap<u32, SendMsgInfo>, // msg_id -> SendMsg
@@ -25,10 +27,13 @@ impl State {
     pub fn new(
         can_to_ui_tx: std::sync::mpsc::Sender<messages::MsgFromCan>,
         ui_to_can_rx: std::sync::mpsc::Receiver<messages::MsgFromUi>,
+        current_source: Option<connection::ConnectionSource>,
     ) -> Self {
         Self {
             can_to_ui_tx,
             ui_to_can_rx,
+            driver: None,
+            current_source,
             is_connected: false,
             parser: None,
             send_msgs: std::collections::HashMap::new(),

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -4,7 +4,8 @@ const NO_CONNECTION_SLEEP_MS: u64 = 200;
 const READ_RETRY_SLEEP_MS: u64 = 2;
 const BUS_LOAD_UPDATE_MS: u128 = 200;
 
-fn process_can_frame(frame: slcan::CanFrame, state: &can::state::State) {
+// Returns the number of payload data bytes in the CAN frame if it was a Can2 frame
+fn process_can_frame(frame: slcan::CanFrame, state: &can::state::State) -> usize {
     match frame {
         slcan::CanFrame::Can2(frame2) => {
             let id = match frame2.id() {
@@ -41,6 +42,8 @@ fn process_can_frame(frame: slcan::CanFrame, state: &can::state::State) {
                     data
                 );
             }
+
+            data.len()
         }
         slcan::CanFrame::CanFd(frame_fd) => {
             let id = match frame_fd.id() {
@@ -52,6 +55,9 @@ fn process_can_frame(frame: slcan::CanFrame, state: &can::state::State) {
                 id,
                 frame_fd.data().len()
             );
+
+            let data = frame_fd.data();
+            data.len()
         }
     }
 }
@@ -217,8 +223,8 @@ pub fn start_can_thread(
 
             match active_driver.read_frame() {
                 Ok(frame) => {
-                    process_can_frame(frame, &state);
-                    state.bus_load_tracker.record_frame();
+                    let data_bytes = process_can_frame(frame, &state);
+                    state.bus_load_tracker.record_frame(data_bytes);
 
                     // Send bus load updates periodically
                     if state.last_bus_load_update.elapsed().as_millis() >= BUS_LOAD_UPDATE_MS {

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -61,9 +61,7 @@ pub fn start_can_thread(
     selected_source: Option<connection::ConnectionSource>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        let mut state = can::state::State::new(can_to_ui_tx, ui_to_can_rx);
-        let mut driver: Option<Box<dyn can::driver::Driver>> = None;
-        let mut current_source: Option<connection::ConnectionSource> = selected_source;
+        let mut state = can::state::State::new(can_to_ui_tx, ui_to_can_rx, selected_source);
 
         // MAIN LOOP
         loop {
@@ -81,7 +79,7 @@ pub fn start_can_thread(
                     }
                     messages::MsgFromUi::Connect(source) => {
                         // Close existing connection if any
-                        if let Some(mut old_driver) = driver.take() {
+                        if let Some(mut old_driver) = state.driver.take() {
                             let _ = old_driver.close();
                         }
                         state.is_connected = false;
@@ -89,7 +87,7 @@ pub fn start_can_thread(
                             .can_to_ui_tx
                             .send(messages::MsgFromCan::Disconnection)
                             .expect("Failed to send disconnected message");
-                        current_source = Some(source);
+                        state.current_source = Some(source);
                     }
                     messages::MsgFromUi::AddSendMessage(add_send_msg) => {
                         state.add_send_message(add_send_msg);
@@ -101,7 +99,7 @@ pub fn start_can_thread(
             }
             let msgs_to_send = state.send_this_tick();
             for msg in msgs_to_send {
-                if let Some(ref mut active_driver) = driver {
+                if let Some(ref mut active_driver) = state.driver {
                     let id = if msg.is_msg_id_extended {
                         slcan::ExtendedId::new(msg.msg_id).map(slcan::Id::Extended)
                     } else if msg.msg_id <= 0x7FF {
@@ -142,7 +140,7 @@ pub fn start_can_thread(
                                 Err(e) => {
                                     log::error!("Failed to send CAN frame: {:?}", e);
                                     state.is_connected = false;
-                                    if let Some(ref source) = current_source {
+                                    if let Some(ref source) = state.current_source {
                                         let error_msg = match source {
                                             connection::ConnectionSource::Serial(path) => {
                                                 path.clone()
@@ -156,7 +154,7 @@ pub fn start_can_thread(
                                             .send(messages::MsgFromCan::ConnectionFailed(error_msg))
                                             .expect("Failed to send connection failed message");
                                     }
-                                    driver = None;
+                                    state.driver = None;
                                 }
                             }
                         } else {
@@ -175,11 +173,11 @@ pub fn start_can_thread(
             }
 
             // Attempt to connect if we don't have a driver but have a source
-            if driver.is_none() {
-                if let Some(ref source) = current_source {
+            if state.driver.is_none() {
+                if let Some(ref source) = state.current_source {
                     match can::driver::create_driver(source) {
                         Ok(new_driver) => {
-                            driver = Some(new_driver);
+                            state.driver = Some(new_driver);
                             state.is_connected = true;
                             state
                                 .can_to_ui_tx
@@ -211,7 +209,7 @@ pub fn start_can_thread(
             }
 
             // Try to read a frame from the driver
-            let Some(ref mut active_driver) = driver else {
+            let Some(ref mut active_driver) = state.driver else {
                 std::thread::sleep(std::time::Duration::from_millis(NO_CONNECTION_SLEEP_MS));
                 continue;
             };
@@ -232,7 +230,7 @@ pub fn start_can_thread(
                             // Actual error, disconnect
                             log::error!("Driver read error: {:?}", other);
                             state.is_connected = false;
-                            if let Some(ref source) = current_source {
+                            if let Some(ref source) = state.current_source {
                                 let error_msg = match source {
                                     connection::ConnectionSource::Serial(path) => path.clone(),
                                     connection::ConnectionSource::Udp(port) => {
@@ -244,14 +242,14 @@ pub fn start_can_thread(
                                     .send(messages::MsgFromCan::ConnectionFailed(error_msg))
                                     .expect("Failed to send connection failed message");
                             }
-                            driver = None;
+                            state.driver = None;
                         }
                     }
                 }
                 Err(e) => {
                     log::error!("Unexpected driver error: {:?}", e);
                     state.is_connected = false;
-                    driver = None;
+                    state.driver = None;
                 }
             }
         }

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -2,6 +2,7 @@ use crate::{can, connection, messages};
 
 const NO_CONNECTION_SLEEP_MS: u64 = 200;
 const READ_RETRY_SLEEP_MS: u64 = 2;
+const BUS_LOAD_UPDATE_MS: u128 = 200;
 
 fn process_can_frame(frame: slcan::CanFrame, state: &can::state::State) {
     match frame {
@@ -217,6 +218,30 @@ pub fn start_can_thread(
             match active_driver.read_frame() {
                 Ok(frame) => {
                     process_can_frame(frame, &state);
+                    state.bus_load_tracker.record_frame();
+
+                    // Send bus load updates periodically
+                    if state.last_bus_load_update.elapsed().as_millis()
+                        >= BUS_LOAD_UPDATE_MS
+                    {
+                        state.bus_load_tracker.cleanup();
+                        let load_1s = state.bus_load_tracker.get_load(1);
+                        let load_5s = state.bus_load_tracker.get_load(5);
+                        let load_10s = state.bus_load_tracker.get_load(10);
+                        let load_30s = state.bus_load_tracker.get_load(30);
+
+                        state
+                            .can_to_ui_tx
+                            .send(messages::MsgFromCan::BusLoad {
+                                load_1s,
+                                load_5s,
+                                load_10s,
+                                load_30s,
+                            })
+                            .expect("Failed to send bus load message");
+
+                        state.last_bus_load_update = std::time::Instant::now();
+                    }
                 }
                 Err(can::driver::DriverError::ReadError(error_type)) => {
                     match error_type {

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -221,9 +221,7 @@ pub fn start_can_thread(
                     state.bus_load_tracker.record_frame();
 
                     // Send bus load updates periodically
-                    if state.last_bus_load_update.elapsed().as_millis()
-                        >= BUS_LOAD_UPDATE_MS
-                    {
+                    if state.last_bus_load_update.elapsed().as_millis() >= BUS_LOAD_UPDATE_MS {
                         state.bus_load_tracker.cleanup();
                         let load_1s = state.bus_load_tracker.get_load(1);
                         let load_5s = state.bus_load_tracker.get_load(5);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,11 @@ fn main() -> eframe::Result<()> {
     let (ui_to_can_tx, ui_to_can_rx) = std::sync::mpsc::channel::<messages::MsgFromUi>();
 
     let settings = settings::Settings::load();
+    if let Some(ref dbc_path) = settings.dbc_path {
+        ui_to_can_tx
+            .send(messages::MsgFromUi::DbcSelected(dbc_path.clone()))
+            .expect("Failed to send DBC path to CAN thread");
+    }
     if let Some(ref selected_source) = settings.selected_source {
         ui_to_can_tx
             .send(messages::MsgFromUi::Connect(selected_source.clone()))

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -17,6 +17,12 @@ pub enum MsgFromCan {
         timestamp: chrono::DateTime<chrono::Local>,
         amount_left: Option<SendAmount>,
     },
+    BusLoad {
+        load_1s: f32,
+        load_5s: f32,
+        load_10s: f32,
+        load_30s: f32,
+    },
 }
 
 #[derive(Clone, Copy)]

--- a/src/ui/bus_load.rs
+++ b/src/ui/bus_load.rs
@@ -5,16 +5,16 @@ const PLOT_TIME_WINDOW_SECS: f64 = 30.0;
 
 pub struct BusLoad {
     pub title: String,
-    
-	pub load_1s: f32,
+
+    pub load_1s: f32,
     pub load_5s: f32,
     pub load_10s: f32,
     pub load_30s: f32,
 
-	pub max_1s: f32,
-	pub max_5s: f32,
-	pub max_10s: f32,
-	pub max_30s: f32,
+    pub max_1s: f32,
+    pub max_5s: f32,
+    pub max_10s: f32,
+    pub max_30s: f32,
 
     pub window: std::collections::VecDeque<(f64, f64)>, // (time, load)
 }
@@ -28,10 +28,10 @@ impl BusLoad {
             load_10s: 0.0,
             load_30s: 0.0,
 
-			max_1s: 0.0,
-			max_5s: 0.0,
-			max_10s: 0.0,
-			max_30s: 0.0,
+            max_1s: 0.0,
+            max_5s: 0.0,
+            max_10s: 0.0,
+            max_30s: 0.0,
 
             window: std::collections::VecDeque::new(),
         }
@@ -90,7 +90,7 @@ impl BusLoad {
                         .strong()
                         .color(ui.style().visuals.text_color()),
                 );
-				ui.label(
+                ui.label(
                     egui::RichText::new("Max Load %")
                         .strong()
                         .color(ui.style().visuals.text_color()),
@@ -100,33 +100,33 @@ impl BusLoad {
                 // 1 second
                 ui.label("1 second");
                 let color_1s = self.get_color(self.load_1s);
-				let max_color_1s = self.get_color(self.max_1s);
+                let max_color_1s = self.get_color(self.max_1s);
                 ui.colored_label(color_1s, format!("{:.2}%", self.load_1s));
-				ui.colored_label(max_color_1s, format!("{:.2}%", self.max_1s));
+                ui.colored_label(max_color_1s, format!("{:.2}%", self.max_1s));
                 ui.end_row();
 
                 // 5 seconds
                 ui.label("5 seconds");
                 let color_5s = self.get_color(self.load_5s);
-				let max_color_5s = self.get_color(self.max_5s);
+                let max_color_5s = self.get_color(self.max_5s);
                 ui.colored_label(color_5s, format!("{:.2}%", self.load_5s));
-				ui.colored_label(max_color_5s, format!("{:.2}%", self.max_5s));
+                ui.colored_label(max_color_5s, format!("{:.2}%", self.max_5s));
                 ui.end_row();
 
                 // 10 seconds
                 ui.label("10 seconds");
                 let color_10s = self.get_color(self.load_10s);
-				let max_color_10s = self.get_color(self.max_10s);
+                let max_color_10s = self.get_color(self.max_10s);
                 ui.colored_label(color_10s, format!("{:.2}%", self.load_10s));
-				ui.colored_label(max_color_10s, format!("{:.2}%", self.max_10s));
+                ui.colored_label(max_color_10s, format!("{:.2}%", self.max_10s));
                 ui.end_row();
 
                 // 30 seconds
                 ui.label("30 seconds");
                 let color_30s = self.get_color(self.load_30s);
-				let max_color_30s = self.get_color(self.max_30s);
+                let max_color_30s = self.get_color(self.max_30s);
                 ui.colored_label(color_30s, format!("{:.2}%", self.load_30s));
-				ui.colored_label(max_color_30s, format!("{:.2}%", self.max_30s));
+                ui.colored_label(max_color_30s, format!("{:.2}%", self.max_30s));
                 ui.end_row();
             });
 
@@ -146,10 +146,10 @@ impl BusLoad {
             self.load_10s = *load_10s;
             self.load_30s = *load_30s;
 
-			self.max_1s = self.max_1s.max(*load_1s);
-			self.max_5s = self.max_5s.max(*load_5s);
-			self.max_10s = self.max_10s.max(*load_10s);
-			self.max_30s = self.max_30s.max(*load_30s);
+            self.max_1s = self.max_1s.max(*load_1s);
+            self.max_5s = self.max_5s.max(*load_5s);
+            self.max_10s = self.max_10s.max(*load_10s);
+            self.max_30s = self.max_30s.max(*load_30s);
 
             let current_time = chrono::Local::now().timestamp_millis() as f64 / 1000.0;
             self.window.push_back((current_time, *load_1s as f64));

--- a/src/ui/bus_load.rs
+++ b/src/ui/bus_load.rs
@@ -1,12 +1,15 @@
 use crate::messages;
 use eframe::egui;
 
+const PLOT_TIME_WINDOW_SECS: f64 = 30.0;
+
 pub struct BusLoad {
     pub title: String,
     pub load_1s: f32,
     pub load_5s: f32,
     pub load_10s: f32,
     pub load_30s: f32,
+    pub window: std::collections::VecDeque<(f64, f64)>, // (time, load)
 }
 
 impl BusLoad {
@@ -17,6 +20,7 @@ impl BusLoad {
             load_5s: 0.0,
             load_10s: 0.0,
             load_30s: 0.0,
+            window: std::collections::VecDeque::new(),
         }
     }
 
@@ -31,6 +35,33 @@ impl BusLoad {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
+        egui_plot::Plot::new(&self.title)
+            .view_aspect(2.0)
+            .auto_bounds(egui::Vec2b::TRUE)
+            // .x_axis_label("Time (seconds)")
+            .y_axis_label("Bus Load (%)")
+            .allow_axis_zoom_drag(false)
+            .show(ui, |plot_ui| {
+                if self.window.is_empty() {
+                    return;
+                }
+
+                let points: egui_plot::PlotPoints = self
+                    .window
+                    .iter()
+                    .map(|(time, value)| [*time, *value])
+                    .collect();
+
+                let line = egui_plot::Line::new("Bus Load (%)", points)
+                    .color(egui::Color32::from_rgb(100, 200, 100))
+                    .stroke(egui::Stroke::new(
+                        2.0,
+                        egui::Color32::from_rgb(100, 200, 100),
+                    ));
+
+                plot_ui.line(line);
+            });
+
         egui::Grid::new(format!("bus_load_grid_{}", self.title))
             .striped(true)
             .spacing([20.0, 10.0])
@@ -88,6 +119,16 @@ impl BusLoad {
             self.load_5s = *load_5s;
             self.load_10s = *load_10s;
             self.load_30s = *load_30s;
+
+            let current_time = chrono::Local::now().timestamp_millis() as f64 / 1000.0;
+            self.window.push_back((current_time, *load_1s as f64));
+            while let Some(&(time, _)) = self.window.front() {
+                if current_time - time > PLOT_TIME_WINDOW_SECS {
+                    self.window.pop_front();
+                } else {
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/ui/bus_load.rs
+++ b/src/ui/bus_load.rs
@@ -5,10 +5,17 @@ const PLOT_TIME_WINDOW_SECS: f64 = 30.0;
 
 pub struct BusLoad {
     pub title: String,
-    pub load_1s: f32,
+    
+	pub load_1s: f32,
     pub load_5s: f32,
     pub load_10s: f32,
     pub load_30s: f32,
+
+	pub max_1s: f32,
+	pub max_5s: f32,
+	pub max_10s: f32,
+	pub max_30s: f32,
+
     pub window: std::collections::VecDeque<(f64, f64)>, // (time, load)
 }
 
@@ -20,6 +27,12 @@ impl BusLoad {
             load_5s: 0.0,
             load_10s: 0.0,
             load_30s: 0.0,
+
+			max_1s: 0.0,
+			max_5s: 0.0,
+			max_10s: 0.0,
+			max_30s: 0.0,
+
             window: std::collections::VecDeque::new(),
         }
     }
@@ -77,30 +90,43 @@ impl BusLoad {
                         .strong()
                         .color(ui.style().visuals.text_color()),
                 );
+				ui.label(
+                    egui::RichText::new("Max Load %")
+                        .strong()
+                        .color(ui.style().visuals.text_color()),
+                );
                 ui.end_row();
 
                 // 1 second
                 ui.label("1 second");
                 let color_1s = self.get_color(self.load_1s);
+				let max_color_1s = self.get_color(self.max_1s);
                 ui.colored_label(color_1s, format!("{:.2}%", self.load_1s));
+				ui.colored_label(max_color_1s, format!("{:.2}%", self.max_1s));
                 ui.end_row();
 
                 // 5 seconds
                 ui.label("5 seconds");
                 let color_5s = self.get_color(self.load_5s);
+				let max_color_5s = self.get_color(self.max_5s);
                 ui.colored_label(color_5s, format!("{:.2}%", self.load_5s));
+				ui.colored_label(max_color_5s, format!("{:.2}%", self.max_5s));
                 ui.end_row();
 
                 // 10 seconds
                 ui.label("10 seconds");
                 let color_10s = self.get_color(self.load_10s);
+				let max_color_10s = self.get_color(self.max_10s);
                 ui.colored_label(color_10s, format!("{:.2}%", self.load_10s));
+				ui.colored_label(max_color_10s, format!("{:.2}%", self.max_10s));
                 ui.end_row();
 
                 // 30 seconds
                 ui.label("30 seconds");
                 let color_30s = self.get_color(self.load_30s);
+				let max_color_30s = self.get_color(self.max_30s);
                 ui.colored_label(color_30s, format!("{:.2}%", self.load_30s));
+				ui.colored_label(max_color_30s, format!("{:.2}%", self.max_30s));
                 ui.end_row();
             });
 
@@ -119,6 +145,11 @@ impl BusLoad {
             self.load_5s = *load_5s;
             self.load_10s = *load_10s;
             self.load_30s = *load_30s;
+
+			self.max_1s = self.max_1s.max(*load_1s);
+			self.max_5s = self.max_5s.max(*load_5s);
+			self.max_10s = self.max_10s.max(*load_10s);
+			self.max_30s = self.max_30s.max(*load_30s);
 
             let current_time = chrono::Local::now().timestamp_millis() as f64 / 1000.0;
             self.window.push_back((current_time, *load_1s as f64));

--- a/src/ui/bus_load.rs
+++ b/src/ui/bus_load.rs
@@ -1,0 +1,93 @@
+use crate::messages;
+use eframe::egui;
+
+pub struct BusLoad {
+    pub title: String,
+    pub load_1s: f32,
+    pub load_5s: f32,
+    pub load_10s: f32,
+    pub load_30s: f32,
+}
+
+impl BusLoad {
+    pub fn new(instance: usize) -> Self {
+        Self {
+            title: format!("Bus Load #{}", instance),
+            load_1s: 0.0,
+            load_5s: 0.0,
+            load_10s: 0.0,
+            load_30s: 0.0,
+        }
+    }
+
+    fn get_color(&self, load: f32) -> egui::Color32 {
+        if load < 50.0 {
+            egui::Color32::GREEN
+        } else if load < 80.0 {
+            egui::Color32::YELLOW
+        } else {
+            egui::Color32::RED
+        }
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
+        egui::Grid::new(format!("bus_load_grid_{}", self.title))
+            .striped(true)
+            .spacing([20.0, 10.0])
+            .show(ui, |ui| {
+                // Header
+                ui.label(
+                    egui::RichText::new("Window")
+                        .strong()
+                        .color(ui.style().visuals.text_color()),
+                );
+                ui.label(
+                    egui::RichText::new("Bus Load %")
+                        .strong()
+                        .color(ui.style().visuals.text_color()),
+                );
+                ui.end_row();
+
+                // 1 second
+                ui.label("1 second");
+                let color_1s = self.get_color(self.load_1s);
+                ui.colored_label(color_1s, format!("{:.2}%", self.load_1s));
+                ui.end_row();
+
+                // 5 seconds
+                ui.label("5 seconds");
+                let color_5s = self.get_color(self.load_5s);
+                ui.colored_label(color_5s, format!("{:.2}%", self.load_5s));
+                ui.end_row();
+
+                // 10 seconds
+                ui.label("10 seconds");
+                let color_10s = self.get_color(self.load_10s);
+                ui.colored_label(color_10s, format!("{:.2}%", self.load_10s));
+                ui.end_row();
+
+                // 30 seconds
+                ui.label("30 seconds");
+                let color_30s = self.get_color(self.load_30s);
+                ui.colored_label(color_30s, format!("{:.2}%", self.load_30s));
+                ui.end_row();
+            });
+
+        egui_tiles::UiResponse::None
+    }
+
+    pub fn handle_can_message(&mut self, msg: &messages::MsgFromCan) {
+        if let messages::MsgFromCan::BusLoad {
+            load_1s,
+            load_5s,
+            load_10s,
+            load_30s,
+        } = msg
+        {
+            self.load_1s = *load_1s;
+            self.load_5s = *load_5s;
+            self.load_10s = *load_10s;
+            self.load_30s = *load_30s;
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod bootloader;
+pub mod bus_load;
 pub mod command_palette;
 pub mod log_parser;
 pub mod scope;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -64,6 +64,11 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                     .push(action::AppAction::SpawnWidget(action::WidgetType::SendUi));
             }
 
+            if ui.button("Add Bus Load").clicked() {
+                app.action_queue
+                    .push(action::AppAction::SpawnWidget(action::WidgetType::BusLoad));
+            }
+
             ui.separator();
             ui.heading("Connection Settings");
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -8,6 +8,7 @@ pub enum Widget {
     Scope(ui::scope::Scope),
     LogParser(ui::log_parser::LogParser),
     SendUi(ui::send::SendUi),
+    BusLoad(ui::bus_load::BusLoad),
 }
 
 impl Widget {
@@ -19,6 +20,7 @@ impl Widget {
             Widget::Scope(w) => &w.title,
             Widget::LogParser(w) => &w.title,
             Widget::SendUi(w) => &w.title,
+            Widget::BusLoad(w) => &w.title,
         }
     }
 
@@ -49,6 +51,7 @@ impl Widget {
             Widget::Scope(w) => w.show(ui),
             Widget::LogParser(w) => w.show(ui, parser),
             Widget::SendUi(w) => w.show(ui, ui_to_can_tx, parser),
+            Widget::BusLoad(w) => w.show(ui),
         }
     }
 
@@ -58,6 +61,7 @@ impl Widget {
             Widget::ViewerList(w) => w.handle_can_message(msg),
             Widget::Scope(w) => w.handle_can_message(msg),
             Widget::SendUi(w) => w.handle_can_message(msg),
+            Widget::BusLoad(w) => w.handle_can_message(msg),
             _ => {}
         }
     }


### PR DESCRIPTION
- CAN thread calculates bus load and periodically sends it to UI thread
- Bus Load widget which has a plot + a table to show bus load over 1/5/10/30s
- UI also tracks max bus load

Also:
- Fixes the DBC setting load on start for the CAN thread