### PR TITLE
Improve log parsing: work done in a new thread + UI displays updates/status

### DIFF
--- a/src/daq_log_parse/consts.rs
+++ b/src/daq_log_parse/consts.rs
@@ -1,9 +1,9 @@
-pub const CAN_EFF_FLAG: u32 = 0x80000000;
+// pub const CAN_EFF_FLAG: u32 = 0x80000000;
 pub const CAN_EID_MASK: u32 = 0x1FFFFFFF;
 pub const CAN_STD_ID_MASK: u32 = 0x000007FF;
 
 // identity bit masks
-pub const BUS_ID_MASK: u32 = 0x80000000; // bit 31
+// pub const BUS_ID_MASK: u32 = 0x80000000; // bit 31
 pub const IS_EID_MASK: u32 = 0x40000000;
 pub const MAX_JUMP_MS: u32 = 300_000; // 300 seconds
 

--- a/src/daq_log_parse/parse.rs
+++ b/src/daq_log_parse/parse.rs
@@ -43,22 +43,37 @@ fn parse_log_file(in_file: &std::path::Path, parser: &can_decode::Parser) -> Vec
     let mut content = std::fs::read(in_file).unwrap();
 
     // add padding zeroes if content length is not multiple of raw frame size
+    let mut added_padding = false;
     if !content
         .len()
         .is_multiple_of(std::mem::size_of::<RawFrame>())
     {
-        log::warn!("Failed to parse log file - possibly due to outdated log format");
+        log::warn!(
+            "Log file {} has length {} which is not a multiple of frame size {}. Possibly due to outdated log format.",
+            in_file.display(),
+            content.len(),
+            std::mem::size_of::<RawFrame>()
+        );
         content.extend(vec![
             0;
             std::mem::size_of::<RawFrame>()
                 - (content.len() % std::mem::size_of::<RawFrame>())
         ]);
+        added_padding = true;
     }
     let frames = bytemuck::try_cast_slice::<u8, RawFrame>(&content)
-        .expect("Failed to parse log file - possibly due to outdated log format (shouldn't reach here if padding is added correctly");
+        .expect("Padding should ensure this does not fail.");
     let mut parsed = Vec::with_capacity(frames.len());
 
-    for frame in frames {
+    for (i, frame) in frames.iter().enumerate() {
+        if added_padding && i == frames.len() - 1 {
+            log::info!(
+                "Skipping last frame in {} due to padding",
+                in_file.display()
+            );
+            break;
+        }
+
         let arb_id = if (frame.identity & consts::IS_EID_MASK) != 0 {
             frame.identity & consts::CAN_EID_MASK
         } else {

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -8,7 +8,8 @@ pub struct TableBuilder {
     message_row: Vec<String>,
     signal_row: Vec<String>,
 
-    indexer: std::collections::HashMap<String, usize>, // key is "msg|signal", value is column index
+    // Key is (msg name, signal name), value is column index
+    indexer: std::collections::HashMap<(String, String), usize>,
 }
 
 impl TableBuilder {
@@ -45,7 +46,7 @@ impl TableBuilder {
             };
 
             for sig in msg.signals {
-                let key = format!("{}|{}", msg.name, sig.name);
+                let key = (msg.name.clone(), sig.name.clone());
                 if let std::collections::hash_map::Entry::Vacant(e) = self.indexer.entry(key) {
                     e.insert(col_idx);
                     col_idx += 1;
@@ -94,7 +95,7 @@ impl TableBuilder {
             for msg in chunk {
                 let decoded = &msg.decoded;
                 for (sig_name, sig_value) in &decoded.signals {
-                    let key = format!("{}|{}", decoded.name, sig_name);
+                    let key = (decoded.name.clone(), sig_name.clone());
                     if let Some(&col_idx) = self.indexer.get(&key) {
                         let row_idx = (msg.timestamp - first_row_time) / consts::BIN_WIDTH_MS;
                         if let Some(row) = csv_table.get_mut(row_idx as usize + 4)

--- a/src/ui/bus_load.rs
+++ b/src/ui/bus_load.rs
@@ -51,7 +51,6 @@ impl BusLoad {
         egui_plot::Plot::new(&self.title)
             .view_aspect(2.0)
             .auto_bounds(egui::Vec2b::TRUE)
-            // .x_axis_label("Time (seconds)")
             .y_axis_label("Bus Load (%)")
             .allow_axis_zoom_drag(false)
             .show(ui, |plot_ui| {

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -46,6 +46,7 @@ impl LogParser {
             None => {
                 // TODO: make persistent log directories
                 log::error!("Error: Logs directory not selected");
+                self.parse_text = "Error: Logs directory not selected".to_string();
                 return;
             }
         };
@@ -54,6 +55,7 @@ impl LogParser {
             Some(p) => p,
             None => {
                 log::error!("Error: Output directory not selected");
+                self.parse_text = "Error: Output directory not selected".to_string();
                 return;
             }
         };
@@ -112,7 +114,10 @@ impl LogParser {
                 });
             }
             // TODO: make proper UI indication that parse has failed / not occured
-            None => log::warn!("No DBC selected, not parsing"),
+            None => {
+                log::warn!("No DBC selected, not parsing");
+                self.parse_text = "Error: No DBC selected, not parsing".to_string();
+            }
         }
     }
 

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -7,8 +7,8 @@ pub struct LogParser {
     pub logs_dir: Option<std::path::PathBuf>,
     pub output_dir: Option<std::path::PathBuf>,
 
-    pub parse_to_ui_rx: Option<std::sync::mpsc::Receiver<MsgFromParserThread>>,
-    pub parse_text: String,
+    parse_to_ui_rx: Option<std::sync::mpsc::Receiver<MsgFromParserThread>>,
+    parse_text: String,
 }
 
 enum MsgFromParserThread {

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -51,15 +51,29 @@ impl LogParser {
             Some(p) => {
                 // TODO: make proper UI indication that parse has been completed/successful
 
-                log::info!("Using DBC: {:?}", p.dbc_path);
-                log::info!("Parsing logs from: {}", logs_dir.display());
-                log::info!("Output to: {}", output_dir.display());
-                let parsed = daq_log_parse::parse::parse_log_files(logs_dir, &p.parser);
-                let chunked_parsed = daq_log_parse::parse::chunk_parsed(parsed);
+                let dbc_path = p.dbc_path.clone();
+                let logs_dir = logs_dir.clone();
+                let output_dir = output_dir.clone();
 
-                let mut table_builder = daq_log_parse::table::TableBuilder::new();
-                table_builder.create_header(&p.parser);
-                table_builder.create_and_write_tables(&output_dir, chunked_parsed);
+                std::thread::spawn(move || {
+                    log::info!("Using DBC: {:?}", dbc_path);
+                    log::info!("Parsing logs from: {}", logs_dir.display());
+                    log::info!("Output to: {}", output_dir.display());
+
+                    let Ok(parser) = can_decode::Parser::from_dbc_file(&dbc_path) else {
+                        log::error!("Failed to create CAN parser from DBC file: {:?}", dbc_path);
+                        return;
+                    };
+
+                    let parsed = daq_log_parse::parse::parse_log_files(&logs_dir, &parser);
+                    let chunked_parsed = daq_log_parse::parse::chunk_parsed(parsed);
+
+                    let mut table_builder = daq_log_parse::table::TableBuilder::new();
+                    table_builder.create_header(&parser);
+                    table_builder.create_and_write_tables(&output_dir, chunked_parsed);
+
+                    log::info!("Parsing completed successfully");
+                });
             }
             // TODO: make proper UI indication that parse has failed / not occured
             None => log::warn!("No DBC selected, not parsing"),

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -6,6 +6,15 @@ pub struct LogParser {
     pub title: String,
     pub logs_dir: Option<std::path::PathBuf>,
     pub output_dir: Option<std::path::PathBuf>,
+
+    pub parse_to_ui_rx: Option<std::sync::mpsc::Receiver<MsgFromParserThread>>,
+    pub parse_text: String,
+}
+
+enum MsgFromParserThread {
+    FatalExit(String),
+    SuccessExit(String),
+    Update(String),
 }
 
 impl LogParser {
@@ -14,6 +23,8 @@ impl LogParser {
             title: format!("Log Parser #{}", instance_num),
             logs_dir: None,
             output_dir: None,
+            parse_to_ui_rx: None,
+            parse_text: String::new(),
         }
     }
 
@@ -55,6 +66,10 @@ impl LogParser {
                 let logs_dir = logs_dir.clone();
                 let output_dir = output_dir.clone();
 
+                let (parse_to_ui_tx, parse_to_ui_rx) =
+                    std::sync::mpsc::channel::<MsgFromParserThread>();
+                self.parse_to_ui_rx = Some(parse_to_ui_rx);
+
                 std::thread::spawn(move || {
                     log::info!("Using DBC: {:?}", dbc_path);
                     log::info!("Parsing logs from: {}", logs_dir.display());
@@ -62,8 +77,21 @@ impl LogParser {
 
                     let Ok(parser) = can_decode::Parser::from_dbc_file(&dbc_path) else {
                         log::error!("Failed to create CAN parser from DBC file: {:?}", dbc_path);
+                        parse_to_ui_tx
+                            .send(MsgFromParserThread::FatalExit(
+                                "Failed to create CAN parser from DBC file".to_string(),
+                            ))
+                            .unwrap_or_else(|e| {
+                                log::error!("Failed to send fatal error message to UI: {}", e)
+                            });
                         return;
                     };
+
+                    parse_to_ui_tx
+                        .send(MsgFromParserThread::Update("Parsing logs...".to_string()))
+                        .unwrap_or_else(|e| {
+                            log::error!("Failed to send update message to UI: {}", e)
+                        });
 
                     let parsed = daq_log_parse::parse::parse_log_files(&logs_dir, &parser);
                     let chunked_parsed = daq_log_parse::parse::chunk_parsed(parsed);
@@ -73,6 +101,14 @@ impl LogParser {
                     table_builder.create_and_write_tables(&output_dir, chunked_parsed);
 
                     log::info!("Parsing completed successfully");
+                    parse_to_ui_tx
+                        .send(MsgFromParserThread::SuccessExit(format!(
+                            "Parsing completed successfully. Output at: {}",
+                            output_dir.display()
+                        )))
+                        .unwrap_or_else(|e| {
+                            log::error!("Failed to send success message to UI: {}", e)
+                        });
                 });
             }
             // TODO: make proper UI indication that parse has failed / not occured
@@ -120,6 +156,30 @@ impl LogParser {
         if ui.button("▶ Parse Logs").clicked() {
             self.parse_logs(parser);
         }
+
+        // Parser thread messages
+        if let Some(rx) = &self.parse_to_ui_rx {
+            match rx.try_recv() {
+                Ok(msg) => match msg {
+                    MsgFromParserThread::FatalExit(text) => {
+                        self.parse_text = format!("Error: {}", text);
+                    }
+                    MsgFromParserThread::SuccessExit(text) => {
+                        self.parse_text = text;
+                    }
+                    MsgFromParserThread::Update(text) => {
+                        self.parse_text = text;
+                    }
+                },
+                Err(std::sync::mpsc::TryRecvError::Empty) => {} // No message, do nothing
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    self.parse_to_ui_rx = None;
+                }
+            }
+        }
+
+        ui.separator();
+        ui.label(&self.parse_text);
 
         egui_tiles::UiResponse::None
     }

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -60,65 +60,59 @@ impl LogParser {
             }
         };
 
-        match parser {
-            Some(p) => {
-                // TODO: make proper UI indication that parse has been completed/successful
-
-                let dbc_path = p.dbc_path.clone();
-                let logs_dir = logs_dir.clone();
-                let output_dir = output_dir.clone();
-
-                let (parse_to_ui_tx, parse_to_ui_rx) =
-                    std::sync::mpsc::channel::<MsgFromParserThread>();
-                self.parse_to_ui_rx = Some(parse_to_ui_rx);
-
-                std::thread::spawn(move || {
-                    log::info!("Using DBC: {:?}", dbc_path);
-                    log::info!("Parsing logs from: {}", logs_dir.display());
-                    log::info!("Output to: {}", output_dir.display());
-
-                    let Ok(parser) = can_decode::Parser::from_dbc_file(&dbc_path) else {
-                        log::error!("Failed to create CAN parser from DBC file: {:?}", dbc_path);
-                        parse_to_ui_tx
-                            .send(MsgFromParserThread::FatalExit(
-                                "Failed to create CAN parser from DBC file".to_string(),
-                            ))
-                            .unwrap_or_else(|e| {
-                                log::error!("Failed to send fatal error message to UI: {}", e)
-                            });
-                        return;
-                    };
-
-                    parse_to_ui_tx
-                        .send(MsgFromParserThread::Update("Parsing logs...".to_string()))
-                        .unwrap_or_else(|e| {
-                            log::error!("Failed to send update message to UI: {}", e)
-                        });
-
-                    let parsed = daq_log_parse::parse::parse_log_files(&logs_dir, &parser);
-                    let chunked_parsed = daq_log_parse::parse::chunk_parsed(parsed);
-
-                    let mut table_builder = daq_log_parse::table::TableBuilder::new();
-                    table_builder.create_header(&parser);
-                    table_builder.create_and_write_tables(&output_dir, chunked_parsed);
-
-                    log::info!("Parsing completed successfully");
-                    parse_to_ui_tx
-                        .send(MsgFromParserThread::SuccessExit(format!(
-                            "Parsing completed successfully. Output at: {}",
-                            output_dir.display()
-                        )))
-                        .unwrap_or_else(|e| {
-                            log::error!("Failed to send success message to UI: {}", e)
-                        });
-                });
-            }
-            // TODO: make proper UI indication that parse has failed / not occured
+        let parser_info = match parser {
+            Some(p) => p,
             None => {
-                log::warn!("No DBC selected, not parsing");
+                log::error!("Error: No DBC selected, not parsing");
                 self.parse_text = "Error: No DBC selected, not parsing".to_string();
+                return;
             }
-        }
+        };
+
+        // Clone for lifetimes in thread
+        let dbc_path = parser_info.dbc_path.clone();
+        let logs_dir = logs_dir.clone();
+        let output_dir = output_dir.clone();
+
+        let (parse_to_ui_tx, parse_to_ui_rx) = std::sync::mpsc::channel::<MsgFromParserThread>();
+        self.parse_to_ui_rx = Some(parse_to_ui_rx);
+
+        std::thread::spawn(move || {
+            log::info!("Using DBC: {:?}", dbc_path);
+            log::info!("Parsing logs from: {}", logs_dir.display());
+            log::info!("Output to: {}", output_dir.display());
+
+            let Ok(parser) = can_decode::Parser::from_dbc_file(&dbc_path) else {
+                log::error!("Failed to create CAN parser from DBC file: {:?}", dbc_path);
+                parse_to_ui_tx
+                    .send(MsgFromParserThread::FatalExit(
+                        "Failed to create CAN parser from DBC file".to_string(),
+                    ))
+                    .unwrap_or_else(|e| {
+                        log::error!("Failed to send fatal error message to UI: {}", e)
+                    });
+                return;
+            };
+
+            parse_to_ui_tx
+                .send(MsgFromParserThread::Update("Parsing logs...".to_string()))
+                .unwrap_or_else(|e| log::error!("Failed to send update message to UI: {}", e));
+
+            let parsed = daq_log_parse::parse::parse_log_files(&logs_dir, &parser);
+            let chunked_parsed = daq_log_parse::parse::chunk_parsed(parsed);
+
+            let mut table_builder = daq_log_parse::table::TableBuilder::new();
+            table_builder.create_header(&parser);
+            table_builder.create_and_write_tables(&output_dir, chunked_parsed);
+
+            log::info!("Parsing completed successfully");
+            parse_to_ui_tx
+                .send(MsgFromParserThread::SuccessExit(format!(
+                    "Parsing completed successfully. Output at: {}",
+                    output_dir.display()
+                )))
+                .unwrap_or_else(|e| log::error!("Failed to send success message to UI: {}", e));
+        });
     }
 
     pub fn show(

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -152,7 +152,11 @@ impl LogParser {
         ui.separator();
 
         // Parse button
-        if ui.button("▶ Parse Logs").clicked() {
+        let currently_parsing = self.parse_to_ui_rx.is_some();
+        if ui
+            .add_enabled(!currently_parsing, egui::Button::new("▶ Parse Logs"))
+            .clicked()
+        {
             self.parse_logs(parser);
         }
 


### PR DESCRIPTION
- Actually parsing of logs and generating CSV output done in a new OS thread to avoid blocking the UI
- Log parse widget shows updates/status of the parsing (`mpsc::channel`)
- When parsing and running into a file that is not an exact multiple, it does not parse the message containing padding bytes.
- `TableBuilder.indexer` uses a key type of `(String, String)` instead of formatting a String 
- UI updates are not fool-proof. If the parse thread panics, UI will not be notified. UI is also not notified of failings to parse individual messages.