### PR TITLE
Simulated CAN mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +942,7 @@ dependencies = [
  "env_logger",
  "hashbrown 0.16.1",
  "log",
+ "rand 0.10.0",
  "rfd",
  "serde",
  "serde_json",
@@ -1539,6 +1560,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -2767,7 +2789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2998,7 +3020,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3006,6 +3039,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "range-alloc"
@@ -3288,7 +3327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ env_logger = "0.11.9"
 slcan = { git = "https://github.com/LelsersLasers/slcan", features = ["sync"] }
 serialport = "4.8.1"
 
+rand = "0.10.0"
+
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.9.8"

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -221,12 +221,19 @@ impl Driver for SimulatedDriver {
         if self.connected {
             let mut rng = rand::rng();
 
-            if let Some(parser) = &self.parser {
-                let all_msgs = parser.msg_defs();
-                let random_msg = all_msgs.choose(&mut rng).unwrap();
-                let mut data = vec![0u8; random_msg.size as usize];
+            let random_msg = self.parser.as_ref().and_then(|p| {
+                let msgs = p.msg_defs();
+                if msgs.is_empty() {
+                    None
+                } else {
+                    Some(msgs.choose(&mut rng).expect("msgs is not empty").clone())
+                }
+            });
+
+            if let Some(msg) = random_msg {
+                let mut data = vec![0u8; msg.size as usize];
                 rng.fill_bytes(&mut data);
-                let id = match random_msg.id {
+                let id = match msg.id {
                     can_dbc::MessageId::Extended(id) => slcan::Id::Extended(
                         slcan::ExtendedId::new(id).expect("invalid extended id"),
                     ),

--- a/src/can/driver.rs
+++ b/src/can/driver.rs
@@ -1,4 +1,5 @@
 use crate::connection::ConnectionSource;
+use rand::prelude::*;
 use serialport::{ClearBuffer, SerialPort};
 use slcan::sync::CanSocket;
 use slcan::{CanFrame, NominalBitRate, OperatingMode};
@@ -195,6 +196,84 @@ impl Driver for UdpDriver {
     }
 }
 
+struct SimulatedDriver {
+    connected: bool,
+    pub parser: Option<can_decode::Parser>,
+}
+
+impl SimulatedDriver {
+    fn new(connected: bool, dbc_path: Option<std::path::PathBuf>) -> DriverResult<Self> {
+        if connected {
+            Ok(Self {
+                connected,
+                parser: dbc_path.and_then(|path| can_decode::Parser::from_dbc_file(&path).ok()),
+            })
+        } else {
+            Err(DriverError::ConnectionFailed(
+                "Simulated driver initialized as disconnected".into(),
+            ))
+        }
+    }
+}
+
+impl Driver for SimulatedDriver {
+    fn read_frame(&mut self) -> DriverResult<CanFrame> {
+        if self.connected {
+            let mut rng = rand::rng();
+
+            if let Some(parser) = &self.parser {
+                let all_msgs = parser.msg_defs();
+                let random_msg = all_msgs.choose(&mut rng).unwrap();
+                let mut data = vec![0u8; random_msg.size as usize];
+                rng.fill_bytes(&mut data);
+                let id = match random_msg.id {
+                    can_dbc::MessageId::Extended(id) => slcan::Id::Extended(
+                        slcan::ExtendedId::new(id).expect("invalid extended id"),
+                    ),
+                    can_dbc::MessageId::Standard(id) => slcan::Id::Standard(
+                        slcan::StandardId::new(id).expect("invalid standard id"),
+                    ),
+                };
+                let can_frame = slcan::Can2Frame::new_data(id, &data)
+                    .expect("failed to create CAN frame from random data");
+                Ok(can_frame.into())
+            } else {
+                // If no DBC is loaded, just return random frames with random IDs and data
+                let id = rng.random_range(0..0x7FF);
+                let sid = slcan::StandardId::new(id).expect("invalid standard id");
+                let mut data = [0u8; 8];
+                rng.fill_bytes(&mut data);
+                let can2 = slcan::Can2Frame::new_data(sid, &data)
+                    .expect("failed to create CAN frame from random data");
+                Ok(can2.into())
+            }
+        } else {
+            Err(DriverError::ReadError(DriverReadError::Other(
+                "Simulated driver is disconnected".into(),
+            )))
+        }
+    }
+
+    fn write_frame(&mut self, _frame: CanFrame) -> DriverResult<()> {
+        if self.connected {
+            Ok(())
+        } else {
+            Err(DriverError::WriteError(
+                "Simulated driver is disconnected".into(),
+            ))
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn close(&mut self) -> DriverResult<()> {
+        self.connected = false;
+        Ok(())
+    }
+}
+
 pub fn parse_udp_buffer(buf: &[u8; 2048], num_bytes: usize) -> DriverResult<CanFrame> {
     if num_bytes < 5 {
         return Err(DriverError::ReadError(DriverReadError::Other(format!(
@@ -236,5 +315,9 @@ pub fn create_driver(source: &ConnectionSource) -> DriverResult<Box<dyn Driver>>
     match source {
         ConnectionSource::Serial(path) => Ok(Box::new(SerialDriver::new(path)?)),
         ConnectionSource::Udp(port) => Ok(Box::new(UdpDriver::new(*port)?)),
+        ConnectionSource::Simulated(connected, dbc_path) => Ok(Box::new(SimulatedDriver::new(
+            *connected,
+            dbc_path.clone(),
+        )?)),
     }
 }

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -148,24 +148,7 @@ pub fn start_can_thread(
                                     log::error!("Failed to send CAN frame: {:?}", e);
                                     state.is_connected = false;
                                     if let Some(ref source) = state.current_source {
-                                        let error_msg = match source {
-                                            connection::ConnectionSource::Serial(path) => {
-                                                path.clone()
-                                            }
-                                            connection::ConnectionSource::Udp(port) => {
-                                                format!("UDP:{}", port)
-                                            }
-                                            connection::ConnectionSource::Simulated(
-                                                connected,
-                                                _,
-                                            ) => {
-                                                if *connected {
-                                                    "Simulated (connected)".into()
-                                                } else {
-                                                    "Simulated (disconnected)".into()
-                                                }
-                                            }
-                                        };
+                                        let error_msg = source.display_name();
                                         state
                                             .can_to_ui_tx
                                             .send(messages::MsgFromCan::ConnectionFailed(error_msg))
@@ -204,17 +187,7 @@ pub fn start_can_thread(
                         }
                         Err(e) => {
                             log::error!("Failed to create driver for {:?}: {:?}", source, e);
-                            let error_msg = match source {
-                                connection::ConnectionSource::Serial(path) => path.clone(),
-                                connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
-                                connection::ConnectionSource::Simulated(connected, _) => {
-                                    if *connected {
-                                        "Simulated (connected)".into()
-                                    } else {
-                                        "Simulated (disconnected)".into()
-                                    }
-                                }
-                            };
+                            let error_msg = source.display_name();
                             state
                                 .can_to_ui_tx
                                 .send(messages::MsgFromCan::ConnectionFailed(error_msg))
@@ -277,19 +250,7 @@ pub fn start_can_thread(
                             log::error!("Driver read error: {:?}", other);
                             state.is_connected = false;
                             if let Some(ref source) = state.current_source {
-                                let error_msg = match source {
-                                    connection::ConnectionSource::Serial(path) => path.clone(),
-                                    connection::ConnectionSource::Udp(port) => {
-                                        format!("UDP:{}", port)
-                                    }
-                                    connection::ConnectionSource::Simulated(connected, _) => {
-                                        if *connected {
-                                            "Simulated (connected)".into()
-                                        } else {
-                                            "Simulated (disconnected)".into()
-                                        }
-                                    }
-                                };
+                                let error_msg = source.display_name();
                                 state
                                     .can_to_ui_tx
                                     .send(messages::MsgFromCan::ConnectionFailed(error_msg))

--- a/src/can/thread.rs
+++ b/src/can/thread.rs
@@ -155,6 +155,16 @@ pub fn start_can_thread(
                                             connection::ConnectionSource::Udp(port) => {
                                                 format!("UDP:{}", port)
                                             }
+                                            connection::ConnectionSource::Simulated(
+                                                connected,
+                                                _,
+                                            ) => {
+                                                if *connected {
+                                                    "Simulated (connected)".into()
+                                                } else {
+                                                    "Simulated (disconnected)".into()
+                                                }
+                                            }
                                         };
                                         state
                                             .can_to_ui_tx
@@ -197,6 +207,13 @@ pub fn start_can_thread(
                             let error_msg = match source {
                                 connection::ConnectionSource::Serial(path) => path.clone(),
                                 connection::ConnectionSource::Udp(port) => format!("UDP:{}", port),
+                                connection::ConnectionSource::Simulated(connected, _) => {
+                                    if *connected {
+                                        "Simulated (connected)".into()
+                                    } else {
+                                        "Simulated (disconnected)".into()
+                                    }
+                                }
                             };
                             state
                                 .can_to_ui_tx
@@ -264,6 +281,13 @@ pub fn start_can_thread(
                                     connection::ConnectionSource::Serial(path) => path.clone(),
                                     connection::ConnectionSource::Udp(port) => {
                                         format!("UDP:{}", port)
+                                    }
+                                    connection::ConnectionSource::Simulated(connected, _) => {
+                                        if *connected {
+                                            "Simulated (connected)".into()
+                                        } else {
+                                            "Simulated (disconnected)".into()
+                                        }
                                     }
                                 };
                                 state

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,4 +2,5 @@
 pub enum ConnectionSource {
     Serial(String),
     Udp(u16),
+    Simulated(bool, Option<std::path::PathBuf>), // true for connected, false for disconnected, path to dbc file for sim
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,3 +4,19 @@ pub enum ConnectionSource {
     Udp(u16),
     Simulated(bool, Option<std::path::PathBuf>), // true for connected, false for disconnected, path to dbc file for sim
 }
+
+impl ConnectionSource {
+    pub fn display_name(&self) -> String {
+        match self {
+            ConnectionSource::Serial(path) => format!("Serial: {}", path),
+            ConnectionSource::Udp(port) => format!("UDP: {}", port),
+            ConnectionSource::Simulated(connected, _) => {
+                if *connected {
+                    "Simulated (connected)".into()
+                } else {
+                    "Simulated (disconnected)".into()
+                }
+            }
+        }
+    }
+}

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -84,15 +84,7 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
 
             ui.horizontal(|ui| {
                 let selected_text = match &app.selected_source {
-                    Some(connection::ConnectionSource::Serial(p)) => format!("Serial: {}", p),
-                    Some(connection::ConnectionSource::Udp(p)) => format!("UDP: {}", p),
-                    Some(connection::ConnectionSource::Simulated(connected, _)) => {
-                        if *connected {
-                            "Simulated (connected)".into()
-                        } else {
-                            "Simulated (disconnected)".into()
-                        }
-                    }
+                    Some(connection_source) => connection_source.display_name(),
                     None => "Select Source".to_string(),
                 };
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -86,6 +86,13 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                 let selected_text = match &app.selected_source {
                     Some(connection::ConnectionSource::Serial(p)) => format!("Serial: {}", p),
                     Some(connection::ConnectionSource::Udp(p)) => format!("UDP: {}", p),
+                    Some(connection::ConnectionSource::Simulated(connected, _)) => {
+                        if *connected {
+                            "Simulated (connected)".into()
+                        } else {
+                            "Simulated (disconnected)".into()
+                        }
+                    }
                     None => "Select Source".to_string(),
                 };
 
@@ -125,6 +132,35 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                         {
                             app.connect_can();
                             app.save_settings();
+                        }
+                        ui.separator();
+                        ui.label("Simulated");
+                        let dbc_path = app.parser.as_ref().map(|p| p.dbc_path.clone());
+                        let sim_sources = [
+                            connection::ConnectionSource::Simulated(true, dbc_path.clone()),
+                            connection::ConnectionSource::Simulated(false, dbc_path.clone()),
+                        ];
+                        for sim_source in sim_sources {
+                            let label = match sim_source {
+                                connection::ConnectionSource::Simulated(true, _) => {
+                                    "Simulated (connected)"
+                                }
+                                connection::ConnectionSource::Simulated(false, _) => {
+                                    "Simulated (disconnected)"
+                                }
+                                _ => unreachable!(),
+                            };
+                            if ui
+                                .selectable_value(
+                                    &mut app.selected_source,
+                                    Some(sim_source.clone()),
+                                    label,
+                                )
+                                .changed()
+                            {
+                                app.connect_can();
+                                app.save_settings();
+                            }
                         }
                     });
 


### PR DESCRIPTION
- New driver options: `Simulated (connect)` and `Simulated (disconnect)`
- Generates random messages from the parser or random bytes if no parser supplied
  - Parser supplied once from UI state
  - So if you change the the DBC file, you have to re-select `Simulated (connect)` for it to take effect.