### PR TITLE
On SendUi close, stop sending messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -169,9 +169,10 @@ impl DAQApp {
                     action::WidgetType::LogParser => widgets::Widget::LogParser(
                         ui::log_parser::LogParser::new(self.next_log_parser_num),
                     ),
-                    action::WidgetType::SendUi => {
-                        widgets::Widget::SendUi(ui::send::SendUi::new(self.next_send_ui_num))
-                    }
+                    action::WidgetType::SendUi => widgets::Widget::SendUi(ui::send::SendUi::new(
+                        self.next_send_ui_num,
+                        self.ui_to_can_tx.clone(),
+                    )),
                     action::WidgetType::BusLoad => {
                         widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.next_bus_load_num))
                     }

--- a/src/ui/send.rs
+++ b/src/ui/send.rs
@@ -54,9 +54,17 @@ impl Drop for SendUi {
         );
         for msg in &self.sending_messages {
             let msg_id = msg.msg_id;
-            self.ui_to_can_tx_copy
+            if let Err(e) = self
+                .ui_to_can_tx_copy
                 .send(messages::MsgFromUi::DeleteSendMessage { msg_id })
-                .expect("Failed to send DeleteSendMessage");
+            {
+                // Don't panic in Drop, just log the error
+                log::error!(
+                    "Failed to send DeleteSendMessage for msg_id {}: {}",
+                    msg_id,
+                    e
+                );
+            }
         }
     }
 }

--- a/src/ui/send.rs
+++ b/src/ui/send.rs
@@ -17,6 +17,9 @@ pub struct SendUi {
     finite_amount: usize,
 
     error: Option<String>,
+
+    // For DROP
+    ui_to_can_tx_copy: std::sync::mpsc::Sender<messages::MsgFromUi>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -39,8 +42,27 @@ enum SendUiActions {
     DeleteMessage { msg_id: u32 },
 }
 
+impl Drop for SendUi {
+    fn drop(&mut self) {
+        // When the Send UI is closed, we want to stop all sending messages
+        log::info!(
+            "Dropping SendUi, stopping all sending messages: {:?}",
+            self.sending_messages
+                .iter()
+                .map(|msg| msg.msg_id)
+                .collect::<Vec<_>>()
+        );
+        for msg in &self.sending_messages {
+            let msg_id = msg.msg_id;
+            self.ui_to_can_tx_copy
+                .send(messages::MsgFromUi::DeleteSendMessage { msg_id })
+                .expect("Failed to send DeleteSendMessage");
+        }
+    }
+}
+
 impl SendUi {
-    pub fn new(num: usize) -> Self {
+    pub fn new(num: usize, ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>) -> Self {
         Self {
             title: format!("Send UI {}", num),
 
@@ -57,6 +79,8 @@ impl SendUi {
             finite_amount: 10,
 
             error: None,
+
+            ui_to_can_tx_copy: ui_to_can_tx,
         }
     }
 

--- a/src/ui/send.rs
+++ b/src/ui/send.rs
@@ -19,7 +19,7 @@ pub struct SendUi {
     error: Option<String>,
 
     // Required to be stored on the struct so Drop can send cancellation messages when the UI closes
-    ui_to_can_tx_drop: std::sync::mpsc::Sender<messages::MsgFromUi>,
+    ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -55,7 +55,7 @@ impl Drop for SendUi {
         for msg in &self.sending_messages {
             let msg_id = msg.msg_id;
             if let Err(e) = self
-                .ui_to_can_tx_drop
+                .ui_to_can_tx
                 .send(messages::MsgFromUi::DeleteSendMessage { msg_id })
             {
                 // Don't panic in Drop, just log the error
@@ -88,14 +88,13 @@ impl SendUi {
 
             error: None,
 
-            ui_to_can_tx_drop: ui_to_can_tx,
+            ui_to_can_tx,
         }
     }
 
     pub fn show(
         &mut self,
         ui: &mut egui::Ui,
-        ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
         parser: Option<&app::ParserInfo>,
     ) -> egui_tiles::UiResponse {
         let Some(parser) = parser else {
@@ -311,7 +310,7 @@ impl SendUi {
                             self.selected_msg = None;
                             self.signal_values.clear();
 
-                            ui_to_can_tx
+                            self.ui_to_can_tx
                                 .send(messages::MsgFromUi::AddSendMessage(add_send_msg))
                                 .expect("Failed to send AddSendMessage");
                         }
@@ -349,7 +348,7 @@ impl SendUi {
                         match action {
                             SendUiActions::DeleteMessage { msg_id } => {
                                 self.sending_messages.retain(|msg| msg.msg_id != msg_id);
-                                ui_to_can_tx
+                                self.ui_to_can_tx
                                     .send(messages::MsgFromUi::DeleteSendMessage { msg_id })
                                     .expect("Failed to send DeleteSendMessage");
                             }

--- a/src/ui/send.rs
+++ b/src/ui/send.rs
@@ -18,8 +18,8 @@ pub struct SendUi {
 
     error: Option<String>,
 
-    // For DROP
-    ui_to_can_tx_copy: std::sync::mpsc::Sender<messages::MsgFromUi>,
+    // Required to be stored on the struct so Drop can send cancellation messages when the UI closes
+    ui_to_can_tx_drop: std::sync::mpsc::Sender<messages::MsgFromUi>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -55,7 +55,7 @@ impl Drop for SendUi {
         for msg in &self.sending_messages {
             let msg_id = msg.msg_id;
             if let Err(e) = self
-                .ui_to_can_tx_copy
+                .ui_to_can_tx_drop
                 .send(messages::MsgFromUi::DeleteSendMessage { msg_id })
             {
                 // Don't panic in Drop, just log the error
@@ -88,7 +88,7 @@ impl SendUi {
 
             error: None,
 
-            ui_to_can_tx_copy: ui_to_can_tx,
+            ui_to_can_tx_drop: ui_to_can_tx,
         }
     }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -50,7 +50,7 @@ impl Widget {
             Widget::Bootloader(w) => w.show(ui),
             Widget::Scope(w) => w.show(ui),
             Widget::LogParser(w) => w.show(ui, parser),
-            Widget::SendUi(w) => w.show(ui, ui_to_can_tx, parser),
+            Widget::SendUi(w) => w.show(ui, parser),
             Widget::BusLoad(w) => w.show(ui),
         }
     }


### PR DESCRIPTION
When the SendUI is closed (and thus dropped), it now requests that all of it's messages stop sending. Previously all messages would continue to be sent with no good way to cancel them.