### PR TITLE
GPS time correlation on log file parsing

### DIFF
--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -124,7 +124,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
                     let dt_local = chrono::DateTime::<chrono::Local>::from(dt_utc);
 
                     let current_year = chrono::Local::now().year();
-                    if dt_local.year() < current_year - 1 || dt_local.year() > current_year + 1 {
+                    if dt_local.year() < current_year - 2 || dt_local.year() > current_year + 2 {
                         log::warn!(
                             "GPS message at {} ms has suspicious year value {}, skipping",
                             msg.timestamp,

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -134,11 +134,6 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
                     }
 
                     gps_points.push((msg.timestamp, dt_local));
-                    println!(
-                        "Found GPS point: log timestamp = {} ms, real timestamp = {}",
-                        msg.timestamp,
-                        dt_local.format("%Y-%m-%d %H:%M:%S%.3f")
-                    );
                 } else {
                     log::error!(
                         "GPS message at {} ms has invalid date/time values, skipping",

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -17,7 +17,7 @@ impl CorrelationFunction {
 }
 
 pub struct CorrelationChunkResult {
-    chunk: Vec<ParsedMessage>,
+    parsed_msgs: Vec<ParsedMessage>,
     correlation_fn: Option<CorrelationFunction>,
 }
 
@@ -31,14 +31,14 @@ pub fn time_correlate_chunks(chunks: Vec<Vec<ParsedMessage>>) -> Vec<Correlation
 impl CorrelationChunkResult {
     pub fn uncorrelated_new(chunk: Vec<ParsedMessage>) -> Self {
         Self {
-            chunk,
+            parsed_msgs: chunk,
             correlation_fn: None,
         }
     }
 
     pub fn correlated_new(chunk: Vec<ParsedMessage>, correlation_fn: CorrelationFunction) -> Self {
         Self {
-            chunk,
+            parsed_msgs: chunk,
             correlation_fn: Some(correlation_fn),
         }
     }

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -1,18 +1,24 @@
 use chrono::TimeZone as _;
-use std::ops::Sub as _;
+use chrono::Datelike as _;
 
 use crate::daq_log_parse::parse::ParsedMessage;
 
 pub struct CorrelationFunction {
-    ref_real_ts: chrono::DateTime<chrono::Local>,
-    ref_log_ts: u32,
-    avg_offset: chrono::Duration,
+    /// real_time ~= slope * log_time_ms + intercept_ms
+    ///
+    /// Stored as:
+    /// unix_ms = slope * log_ts_ms + intercept_ms
+    slope: f64,
+    intercept_ms: f64,
 }
+
 impl CorrelationFunction {
     pub fn correlate(&self, log_ts: u32) -> chrono::DateTime<chrono::Local> {
-        self.ref_real_ts
-            + chrono::Duration::milliseconds(log_ts as i64 - self.ref_log_ts as i64)
-            + self.avg_offset
+        let unix_ms = self.slope * log_ts as f64 + self.intercept_ms;
+
+        chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64)
+            .unwrap()
+            .with_timezone(&chrono::Local)
     }
 }
 
@@ -109,17 +115,24 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
                         date.and_hms_milli_opt(h as u32, min as u32, s as u32, ms as u32)
                     })
                 {
-                    let current_year = chrono::Local::now().year_ce().1 as i32;
-                    if full_year < current_year - 1 || full_year > current_year + 1 {
+                    let dt_utc = chrono::Utc.from_utc_datetime(&dt);
+                    let dt_local = chrono::DateTime::<chrono::Local>::from(dt_utc);
+
+                    let current_year = chrono::Local::now().year();
+                    if dt_local.year() < current_year - 1 || dt_local.year() > current_year + 1 {
                         log::warn!(
                             "GPS message at {} ms has suspicious year value {}, skipping",
-                            msg.timestamp, full_year
+                            msg.timestamp, dt_local.year()
                         );
                         continue;
                     }
 
-                    let dt_local = chrono::Local.from_local_datetime(&dt).unwrap();
                     gps_points.push((msg.timestamp, dt_local));
+                    println!(
+                        "Found GPS point: log timestamp = {} ms, real timestamp = {}",
+                        msg.timestamp,
+                        dt_local.format("%Y-%m-%d %H:%M:%S%.3f")
+                    );
                 } else {
                     log::error!(
                         "GPS message at {} ms has invalid date/time values, skipping",
@@ -142,44 +155,91 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         return CorrelationChunkResult::uncorrelated_new(chunk);
     }
 
-    // Attempt to correlate. Use the first GPS point as a reference, and calculate the offset for
-    // each subsequent GPS point. If the offsets are consistent-ish, we can assume a linear
-    // correlation and adjust all timestamps accordingly. If the offsets are wildly inconsistent,
-    // give up on correlation.
-    let (ref_log_ts, ref_real_ts) = gps_points[0];
-    let mut offsets = Vec::new();
-    for (log_ts, real_ts) in &gps_points[1..] {
-        let offset = *real_ts
-            - chrono::Duration::milliseconds(*log_ts as i64)
-            - (ref_real_ts - chrono::Duration::milliseconds(ref_log_ts as i64));
-        offsets.push(offset);
-    }
-
-    // Check if offsets are consistent (within 20 ms of each other)
-    let zero = chrono::Duration::zero();
-    let max_offset = offsets.iter().max().unwrap_or(&zero);
-    let min_offset = offsets.iter().min().unwrap_or(&zero);
-    if max_offset.sub(*min_offset) > chrono::Duration::milliseconds(20) {
-        log::error!(
-            "Offsets between GPS points are inconsistent (max: {:?}, min: {:?}), giving up on correlation",
-            max_offset,
-            min_offset
-        );
-        return CorrelationChunkResult::uncorrelated_new(chunk);
-    }
-
-    // Use the average offset for correlation
-    let avg_offset = offsets
+    let points: Vec<Point> = gps_points
         .iter()
-        .fold(chrono::Duration::zero(), |acc, x| acc + *x)
-        / (offsets.len() as i32);
+        .map(|(log_ts, real_ts)| Point {
+            x: *log_ts as f64,
+            y: real_ts.timestamp_millis() as f64,
+        })
+        .collect();
+    let (slope, intercept) = match linear_regression(&points) {
+        Some(v) => v,
+        None => {
+            log::error!("Failed to refit correlation line");
+            return CorrelationChunkResult::uncorrelated_new(chunk);
+        }
+    };
+
+        let rms_error_ms = {
+        let mse = points
+            .iter()
+            .map(|p| {
+                let predicted = slope * p.x + intercept;
+                let error = p.y - predicted;
+                error * error
+            })
+            .sum::<f64>()
+            / points.len() as f64;
+
+        mse.sqrt()
+    };
+
+    log::info!(
+        "GPS correlation successful: slope={:.9}, intercept_ms={:.3}, rms_error_ms={:.2}, points={}",
+        slope,
+        intercept,
+        rms_error_ms,
+        points.len()
+    );
+
 
     CorrelationChunkResult::correlated_new(
         chunk,
         CorrelationFunction {
-            ref_real_ts,
-            ref_log_ts,
-            avg_offset,
+            slope,
+            intercept_ms: intercept,
         },
     )
+}
+
+
+struct Point {
+    x: f64, // log timestamp ms
+    y: f64, // unix timestamp ms
+}
+
+/// Least squares linear regression.
+///
+/// Fits:
+///
+/// y = slope * x + intercept
+fn linear_regression(points: &[Point]) -> Option<(f64, f64)> {
+    if points.len() < 2 {
+        return None;
+    }
+
+    let n = points.len() as f64;
+
+    let mut sum_x = 0.0;
+    let mut sum_y = 0.0;
+    let mut sum_xy = 0.0;
+    let mut sum_x2 = 0.0;
+
+    for p in points {
+        sum_x += p.x;
+        sum_y += p.y;
+        sum_xy += p.x * p.y;
+        sum_x2 += p.x * p.x;
+    }
+
+    let denom = n * sum_x2 - sum_x * sum_x;
+
+    if denom.abs() < 1e-9 {
+        return None;
+    }
+
+    let slope = (n * sum_xy - sum_x * sum_y) / denom;
+    let intercept = (sum_y - slope * sum_x) / n;
+
+    Some((slope, intercept))
 }

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -66,9 +66,8 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
     // Idea: in the chunk, look for GPS messages which have both a timestamp and a corresponding real time
     // Use those to create a mapping from the log's timestamps to real time, and use that mapping to convert
     // all messages in the chunk to have real timestamps.
-    // If the correlation is successful, we return the time-adjusted messages.
-    // If we can't find any GPS messages, or if the correlation fails for some reason, we return the
-    // original messages without time adjustment.
+    // If the correlation is successful, we return the orginal messages along with a correlation function.
+    // If we can't find any GPS messages, or if the correlation fails, return just the original messages.
 
     // First, find all GPS messages and extract their timestamps and real times
     let mut gps_points = Vec::new();
@@ -156,6 +155,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         return CorrelationChunkResult::uncorrelated_new(chunk);
     }
 
+    // Attempt to fit a line to the GPS points to find the correlation function
     let points: Vec<Point> = gps_points
         .iter()
         .map(|(log_ts, real_ts)| Point {
@@ -171,6 +171,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         }
     };
 
+    // Print debug info about the correlation quality
     let rms_error_ms = {
         let mse = points
             .iter()
@@ -184,7 +185,6 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
 
         mse.sqrt()
     };
-
     log::info!(
         "GPS correlation successful: slope={:.9}, intercept_ms={:.3}, rms_error_ms={:.2}, points={}",
         slope,

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -9,7 +9,7 @@ pub struct CorrelationFunction {
     avg_offset: chrono::Duration,
 }
 impl CorrelationFunction {
-    pub fn correlate(&self, log_ts: u64) -> chrono::DateTime<chrono::Local> {
+    pub fn correlate(&self, log_ts: u32) -> chrono::DateTime<chrono::Local> {
         self.ref_real_ts
             + chrono::Duration::milliseconds(log_ts as i64 - self.ref_log_ts as i64)
             + self.avg_offset
@@ -17,8 +17,8 @@ impl CorrelationFunction {
 }
 
 pub struct CorrelationChunkResult {
-    parsed_msgs: Vec<ParsedMessage>,
-    correlation_fn: Option<CorrelationFunction>,
+    pub parsed_msgs: Vec<ParsedMessage>,
+    pub correlation_fn: Option<CorrelationFunction>,
 }
 
 pub fn time_correlate_chunks(chunks: Vec<Vec<ParsedMessage>>) -> Vec<CorrelationChunkResult> {

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -102,8 +102,9 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
             if let (Some(ms), Some(s), Some(min), Some(h), Some(d), Some(mon), Some(y)) =
                 (millisecond, second, minute, hour, day, month, year)
             {
+                let full_year = if y < 100 { 2000 + y as i32 } else { y as i32 };
                 // Construct a chrono::DateTime from the extracted values
-                if let Some(dt) = chrono::NaiveDate::from_ymd_opt(y as i32, mon as u32, d as u32)
+                if let Some(dt) = chrono::NaiveDate::from_ymd_opt(full_year, mon as u32, d as u32)
                     .and_then(|date| {
                         date.and_hms_milli_opt(h as u32, min as u32, s as u32, ms as u32)
                     })

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -24,7 +24,7 @@ pub struct CorrelationChunkResult {
 pub fn time_correlate_chunks(chunks: Vec<Vec<ParsedMessage>>) -> Vec<CorrelationChunkResult> {
     chunks
         .into_iter()
-        .map(|chunk| time_correlate_chunk(chunk))
+        .map(time_correlate_chunk)
         .collect()
 }
 
@@ -109,6 +109,15 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
                         date.and_hms_milli_opt(h as u32, min as u32, s as u32, ms as u32)
                     })
                 {
+                    let current_year = chrono::Local::now().year_ce().1 as i32;
+                    if full_year < current_year - 1 || full_year > current_year + 1 {
+                        log::warn!(
+                            "GPS message at {} ms has suspicious year value {}, skipping",
+                            msg.timestamp, full_year
+                        );
+                        continue;
+                    }
+
                     let dt_local = chrono::Local.from_local_datetime(&dt).unwrap();
                     gps_points.push((msg.timestamp, dt_local));
                 } else {

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -1,20 +1,47 @@
-use std::ops::Sub as _;
 use chrono::TimeZone as _;
+use std::ops::Sub as _;
 
 use crate::daq_log_parse::parse::ParsedMessage;
 
-
 pub struct CorrelationFunction {
-	ref_real_ts: chrono::DateTime<chrono::Local>,
-	ref_log_ts: u32,
-	avg_offset: chrono::Duration,
+    ref_real_ts: chrono::DateTime<chrono::Local>,
+    ref_log_ts: u32,
+    avg_offset: chrono::Duration,
 }
 impl CorrelationFunction {
-	pub fn correlate(&self, log_ts: u64) -> chrono::DateTime<chrono::Local> {
-		self.ref_real_ts
-			+ chrono::Duration::milliseconds(log_ts as i64 - self.ref_log_ts as i64)
-			+ self.avg_offset
-	}
+    pub fn correlate(&self, log_ts: u64) -> chrono::DateTime<chrono::Local> {
+        self.ref_real_ts
+            + chrono::Duration::milliseconds(log_ts as i64 - self.ref_log_ts as i64)
+            + self.avg_offset
+    }
+}
+
+pub struct CorrelationChunkResult {
+    chunk: Vec<ParsedMessage>,
+    correlation_fn: Option<CorrelationFunction>,
+}
+
+pub fn time_correlate_chunks(chunks: Vec<Vec<ParsedMessage>>) -> Vec<CorrelationChunkResult> {
+    chunks
+        .into_iter()
+        .map(|chunk| time_correlate_chunk(chunk))
+        .collect()
+}
+
+impl CorrelationChunkResult {
+    pub fn uncorrelated_new(chunk: Vec<ParsedMessage>) -> Self {
+        Self {
+            chunk,
+            correlation_fn: None,
+        }
+    }
+
+    pub fn correlated_new(chunk: Vec<ParsedMessage>, correlation_fn: CorrelationFunction) -> Self {
+        Self {
+            chunk,
+            correlation_fn: Some(correlation_fn),
+        }
+    }
 }
 
 pub fn sig_to_value(dsv: &can_decode::DecodedSignalValue) -> u64 {
@@ -24,7 +51,7 @@ pub fn sig_to_value(dsv: &can_decode::DecodedSignalValue) -> u64 {
     }
 }
 
-pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> Option<CorrelationFunction> {
+pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult {
     // Idea: in the chunk, look for GPS messages which have both a timestamp and a corresponding real time
     // Use those to create a mapping from the log's timestamps to real time, and use that mapping to convert
     // all messages in the chunk to have real timestamps.
@@ -102,7 +129,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> Option<CorrelationFunc
 
     if gps_points.is_empty() {
         // No GPS points found, can't correlate
-        return None;
+        return CorrelationChunkResult::uncorrelated_new(chunk);
     }
 
     // Attempt to correlate. Use the first GPS point as a reference, and calculate the offset for
@@ -128,7 +155,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> Option<CorrelationFunc
             max_offset,
             min_offset
         );
-        return None;
+        return CorrelationChunkResult::uncorrelated_new(chunk);
     }
 
     // Use the average offset for correlation
@@ -137,9 +164,12 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> Option<CorrelationFunc
         .fold(chrono::Duration::zero(), |acc, x| acc + *x)
         / (offsets.len() as i32);
 
-    Some(CorrelationFunction {
-		ref_real_ts,
-		ref_log_ts,
-		avg_offset,
-	})
+    CorrelationChunkResult::correlated_new(
+        chunk,
+        CorrelationFunction {
+            ref_real_ts,
+            ref_log_ts,
+            avg_offset,
+        },
+    )
 }

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -1,5 +1,5 @@
-use chrono::TimeZone as _;
 use chrono::Datelike as _;
+use chrono::TimeZone as _;
 
 use crate::daq_log_parse::parse::ParsedMessage;
 
@@ -28,10 +28,7 @@ pub struct CorrelationChunkResult {
 }
 
 pub fn time_correlate_chunks(chunks: Vec<Vec<ParsedMessage>>) -> Vec<CorrelationChunkResult> {
-    chunks
-        .into_iter()
-        .map(time_correlate_chunk)
-        .collect()
+    chunks.into_iter().map(time_correlate_chunk).collect()
 }
 
 impl CorrelationChunkResult {
@@ -122,7 +119,8 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
                     if dt_local.year() < current_year - 1 || dt_local.year() > current_year + 1 {
                         log::warn!(
                             "GPS message at {} ms has suspicious year value {}, skipping",
-                            msg.timestamp, dt_local.year()
+                            msg.timestamp,
+                            dt_local.year()
                         );
                         continue;
                     }
@@ -170,7 +168,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         }
     };
 
-        let rms_error_ms = {
+    let rms_error_ms = {
         let mse = points
             .iter()
             .map(|p| {
@@ -192,7 +190,6 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         points.len()
     );
 
-
     CorrelationChunkResult::correlated_new(
         chunk,
         CorrelationFunction {
@@ -201,7 +198,6 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         },
     )
 }
-
 
 struct Point {
     x: f64, // log timestamp ms

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -13,12 +13,20 @@ pub struct CorrelationFunction {
 }
 
 impl CorrelationFunction {
-    pub fn correlate(&self, log_ts: u32) -> chrono::DateTime<chrono::Local> {
+    pub fn correlate(&self, log_ts: u32) -> Option<chrono::DateTime<chrono::Local>> {
         let unix_ms = self.slope * log_ts as f64 + self.intercept_ms;
 
-        chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64)
-            .unwrap()
-            .with_timezone(&chrono::Local)
+        match chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64) {
+            Some(dt) => Some(dt.with_timezone(&chrono::Local)),
+            None => {
+                log::error!(
+                    "Correlated time {} ms for log time {} ms is out of range for chrono::DateTime",
+                    unix_ms,
+                    log_ts
+                );
+                None
+            }
+        }
     }
 }
 

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -1,16 +1,20 @@
-use std::ops::Sub;
+use std::ops::Sub as _;
+use chrono::TimeZone as _;
 
 use crate::daq_log_parse::parse::ParsedMessage;
-use chrono::TimeZone;
 
-pub struct TimeAdjustedMessage {
-    pub parsed_message: ParsedMessage,
-    pub real_timestamp: chrono::DateTime<chrono::Local>,
+
+pub struct CorrelationFunction {
+	ref_real_ts: chrono::DateTime<chrono::Local>,
+	ref_log_ts: u32,
+	avg_offset: chrono::Duration,
 }
-
-pub enum CorrelatedParsedMessages {
-    TimeAdjusted(Vec<TimeAdjustedMessage>),
-    Unadjusted(Vec<ParsedMessage>),
+impl CorrelationFunction {
+	pub fn correlate(&self, log_ts: u64) -> chrono::DateTime<chrono::Local> {
+		self.ref_real_ts
+			+ chrono::Duration::milliseconds(log_ts as i64 - self.ref_log_ts as i64)
+			+ self.avg_offset
+	}
 }
 
 pub fn sig_to_value(dsv: &can_decode::DecodedSignalValue) -> u64 {
@@ -20,7 +24,7 @@ pub fn sig_to_value(dsv: &can_decode::DecodedSignalValue) -> u64 {
     }
 }
 
-pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelatedParsedMessages {
+pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> Option<CorrelationFunction> {
     // Idea: in the chunk, look for GPS messages which have both a timestamp and a corresponding real time
     // Use those to create a mapping from the log's timestamps to real time, and use that mapping to convert
     // all messages in the chunk to have real timestamps.
@@ -98,7 +102,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelatedParsedMessag
 
     if gps_points.is_empty() {
         // No GPS points found, can't correlate
-        return CorrelatedParsedMessages::Unadjusted(chunk);
+        return None;
     }
 
     // Attempt to correlate. Use the first GPS point as a reference, and calculate the offset for
@@ -124,7 +128,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelatedParsedMessag
             max_offset,
             min_offset
         );
-        return CorrelatedParsedMessages::Unadjusted(chunk);
+        return None;
     }
 
     // Use the average offset for correlation
@@ -133,15 +137,9 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelatedParsedMessag
         .fold(chrono::Duration::zero(), |acc, x| acc + *x)
         / (offsets.len() as i32);
 
-    let time_adjusted_messages = chunk
-        .into_iter()
-        .map(|msg| TimeAdjustedMessage {
-            real_timestamp: ref_real_ts
-                + chrono::Duration::milliseconds(msg.timestamp as i64 - ref_log_ts as i64)
-                + avg_offset,
-            parsed_message: msg,
-        })
-        .collect();
-
-    CorrelatedParsedMessages::TimeAdjusted(time_adjusted_messages)
+    Some(CorrelationFunction {
+		ref_real_ts,
+		ref_log_ts,
+		avg_offset,
+	})
 }

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -1,0 +1,147 @@
+use std::ops::Sub;
+
+use crate::daq_log_parse::parse::ParsedMessage;
+use chrono::TimeZone;
+
+pub struct TimeAdjustedMessage {
+    pub parsed_message: ParsedMessage,
+    pub real_timestamp: chrono::DateTime<chrono::Local>,
+}
+
+pub enum CorrelatedParsedMessages {
+    TimeAdjusted(Vec<TimeAdjustedMessage>),
+    Unadjusted(Vec<ParsedMessage>),
+}
+
+pub fn sig_to_value(dsv: &can_decode::DecodedSignalValue) -> u64 {
+    match &dsv {
+        can_decode::DecodedSignalValue::Numeric(v) => v.round() as u64,
+        can_decode::DecodedSignalValue::Enum(v, _) => *v as u64,
+    }
+}
+
+pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelatedParsedMessages {
+    // Idea: in the chunk, look for GPS messages which have both a timestamp and a corresponding real time
+    // Use those to create a mapping from the log's timestamps to real time, and use that mapping to convert
+    // all messages in the chunk to have real timestamps.
+    // If the correlation is successful, we return the time-adjusted messages.
+    // If we can't find any GPS messages, or if the correlation fails for some reason, we return the
+    // original messages without time adjustment.
+
+    // First, find all GPS messages and extract their timestamps and real times
+    let mut gps_points = Vec::new();
+    for msg in &chunk {
+        if msg.decoded.name == "gps_time" {
+            let millisecond = msg
+                .decoded
+                .signals
+                .get("millisecond")
+                .map(|sig| sig_to_value(&sig.value));
+            let second = msg
+                .decoded
+                .signals
+                .get("second")
+                .map(|sig| sig_to_value(&sig.value));
+            let minute = msg
+                .decoded
+                .signals
+                .get("minute")
+                .map(|sig| sig_to_value(&sig.value));
+            let hour = msg
+                .decoded
+                .signals
+                .get("hour")
+                .map(|sig| sig_to_value(&sig.value));
+            let day = msg
+                .decoded
+                .signals
+                .get("day")
+                .map(|sig| sig_to_value(&sig.value));
+            let month = msg
+                .decoded
+                .signals
+                .get("month")
+                .map(|sig| sig_to_value(&sig.value));
+            let year = msg
+                .decoded
+                .signals
+                .get("year")
+                .map(|sig| sig_to_value(&sig.value));
+
+            if let (Some(ms), Some(s), Some(min), Some(h), Some(d), Some(mon), Some(y)) =
+                (millisecond, second, minute, hour, day, month, year)
+            {
+                // Construct a chrono::DateTime from the extracted values
+                if let Some(dt) = chrono::NaiveDate::from_ymd_opt(y as i32, mon as u32, d as u32)
+                    .and_then(|date| {
+                        date.and_hms_milli_opt(h as u32, min as u32, s as u32, ms as u32)
+                    })
+                {
+                    let dt_local = chrono::Local.from_local_datetime(&dt).unwrap();
+                    gps_points.push((msg.timestamp, dt_local));
+                } else {
+                    log::error!(
+                        "GPS message at {} ms has invalid date/time values, skipping",
+                        msg.timestamp
+                    );
+                    continue;
+                }
+            } else {
+                log::error!(
+                    "GPS message at {} ms is missing some time signals, skipping",
+                    msg.timestamp
+                );
+                continue;
+            }
+        }
+    }
+
+    if gps_points.is_empty() {
+        // No GPS points found, can't correlate
+        return CorrelatedParsedMessages::Unadjusted(chunk);
+    }
+
+    // Attempt to correlate. Use the first GPS point as a reference, and calculate the offset for
+    // each subsequent GPS point. If the offsets are consistent-ish, we can assume a linear
+    // correlation and adjust all timestamps accordingly. If the offsets are wildly inconsistent,
+    // give up on correlation.
+    let (ref_log_ts, ref_real_ts) = gps_points[0];
+    let mut offsets = Vec::new();
+    for (log_ts, real_ts) in &gps_points[1..] {
+        let offset = *real_ts
+            - chrono::Duration::milliseconds(*log_ts as i64)
+            - (ref_real_ts - chrono::Duration::milliseconds(ref_log_ts as i64));
+        offsets.push(offset);
+    }
+
+    // Check if offsets are consistent (within 20 ms of each other)
+    let zero = chrono::Duration::zero();
+    let max_offset = offsets.iter().max().unwrap_or(&zero);
+    let min_offset = offsets.iter().min().unwrap_or(&zero);
+    if max_offset.sub(*min_offset) > chrono::Duration::milliseconds(20) {
+        log::error!(
+            "Offsets between GPS points are inconsistent (max: {:?}, min: {:?}), giving up on correlation",
+            max_offset,
+            min_offset
+        );
+        return CorrelatedParsedMessages::Unadjusted(chunk);
+    }
+
+    // Use the average offset for correlation
+    let avg_offset = offsets
+        .iter()
+        .fold(chrono::Duration::zero(), |acc, x| acc + *x)
+        / (offsets.len() as i32);
+
+    let time_adjusted_messages = chunk
+        .into_iter()
+        .map(|msg| TimeAdjustedMessage {
+            real_timestamp: ref_real_ts
+                + chrono::Duration::milliseconds(msg.timestamp as i64 - ref_log_ts as i64)
+                + avg_offset,
+            parsed_message: msg,
+        })
+        .collect();
+
+    CorrelatedParsedMessages::TimeAdjusted(time_adjusted_messages)
+}

--- a/src/daq_log_parse/mod.rs
+++ b/src/daq_log_parse/mod.rs
@@ -1,3 +1,4 @@
 pub mod consts;
+pub mod correlate;
 pub mod parse;
 pub mod table;

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -114,7 +114,7 @@ impl TableBuilder {
             let first_correlated_time: Option<String> =
                 chunk.correlation_fn.as_ref().and_then(|cf| {
                     cf.correlate(first_time)
-                        .format("%Y_%m_%d_%H_%M_%S%.3f")
+                        .format("%H_%M_%S%.3f")
                         .to_string()
                         .parse()
                         .ok()

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -86,7 +86,7 @@ impl TableBuilder {
                     .as_ref()
                     .map(|cf| cf.correlate(row_time));
                 if let Some(ct) = correlated_time {
-                    row[0] = ct.format("%H:%M:%S%.3f").to_string();
+                    row[0] = ct.format("%H:%M:%S.%3f").to_string();
                 }
                 row[1] = format!("{:.3}", row_time_sec);
                 csv_table.push(row);
@@ -113,7 +113,7 @@ impl TableBuilder {
             let first_correlated_time: Option<String> =
                 chunk.correlation_fn.as_ref().and_then(|cf| {
                     cf.correlate(first_time)
-                        .format("%Y_%m_%d_%H_%M_%S%_3f")
+                        .format("%Y_%m_%d__%H_%M_%S")
                         .to_string()
                         .parse()
                         .ok()

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -84,7 +84,7 @@ impl TableBuilder {
                 let correlated_time = chunk
                     .correlation_fn
                     .as_ref()
-                    .map(|cf| cf.correlate(row_time));
+                    .and_then(|cf| cf.correlate(row_time));
                 if let Some(ct) = correlated_time {
                     row[0] = ct.format("%H:%M:%S.%3f").to_string();
                 }
@@ -113,10 +113,7 @@ impl TableBuilder {
             let first_correlated_time: Option<String> =
                 chunk.correlation_fn.as_ref().and_then(|cf| {
                     cf.correlate(first_time)
-                        .format("%Y_%m_%d__%H_%M_%S")
-                        .to_string()
-                        .parse()
-                        .ok()
+                        .map(|dt| dt.format("%Y_%m_%d__%H_%M_%S").to_string())
                 });
 
             let out_file = match first_correlated_time {

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -1,5 +1,4 @@
-use crate::daq_log_parse::consts;
-use crate::daq_log_parse::parse;
+use crate::daq_log_parse::{consts, correlate};
 use can_decode::DecodedSignalValue;
 
 pub struct TableBuilder {
@@ -16,11 +15,11 @@ pub struct TableBuilder {
 impl TableBuilder {
     pub fn new() -> Self {
         let mut tb = Self {
-            bus_row: vec!["Bus".to_string()],
-            node_row: vec!["Node".to_string()],
-            message_row: vec!["Message".to_string()],
-            signal_row: vec!["Signal".to_string()],
-            next_col_idx: 1,
+            bus_row: vec!["".to_string(), "Bus".to_string()],
+            node_row: vec!["".to_string(), "Node".to_string()],
+            message_row: vec!["".to_string(), "Message".to_string()],
+            signal_row: vec!["".to_string(), "Signal".to_string()],
+            next_col_idx: 2, // real time and then daq time columns
             indexer: std::collections::HashMap::new(),
         };
         tb
@@ -58,11 +57,11 @@ impl TableBuilder {
     pub fn create_and_write_tables(
         &self,
         out_folder: &std::path::Path,
-        chunked_parsed: Vec<Vec<parse::ParsedMessage>>,
+        correlated_chunks: Vec<correlate::CorrelationChunkResult>,
     ) {
         std::fs::create_dir_all(out_folder).unwrap();
 
-        for (chunk_idx, chunk) in chunked_parsed.iter().enumerate() {
+        for (chunk_idx, chunk) in correlated_chunks.iter().enumerate() {
             let mut csv_table = vec![
                 self.bus_row.clone(),
                 self.node_row.clone(),
@@ -70,8 +69,8 @@ impl TableBuilder {
                 self.signal_row.clone(),
             ];
 
-            let first_time = chunk.first().map(|m| m.timestamp).unwrap_or(0);
-            let last_time = chunk.last().map(|m| m.timestamp).unwrap_or(0);
+            let first_time = chunk.parsed_msgs.first().map(|m| m.timestamp).unwrap_or(0);
+            let last_time = chunk.parsed_msgs.last().map(|m| m.timestamp).unwrap_or(0);
 
             let first_row_time = (first_time / consts::BIN_WIDTH_MS) * consts::BIN_WIDTH_MS;
             let last_row_time = last_time.div_ceil(consts::BIN_WIDTH_MS) * consts::BIN_WIDTH_MS;
@@ -83,11 +82,15 @@ impl TableBuilder {
                 let row_time = first_row_time + row_idx * consts::BIN_WIDTH_MS;
                 let row_time_sec = row_time as f32 / 1000.0;
                 let mut row = vec!["".to_string(); self.bus_row.len()];
-                row[0] = format!("{:.3}", row_time_sec);
+                let correlated_time = chunk.correlation_fn.as_ref().map(|cf| cf.correlate(row_time));
+                if let Some(ct) = correlated_time {
+                    row[0] = ct.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+                }
+                row[1] = format!("{:.3}", row_time_sec);
                 csv_table.push(row);
             }
 
-            for msg in chunk {
+            for msg in chunk.parsed_msgs.iter() {
                 let decoded = &msg.decoded;
                 for (sig_name, sig_value) in &decoded.signals {
                     let key = (msg.bus_name.clone(), decoded.name.clone(), sig_name.clone());

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -87,7 +87,7 @@ impl TableBuilder {
                     .as_ref()
                     .map(|cf| cf.correlate(row_time));
                 if let Some(ct) = correlated_time {
-                    row[0] = ct.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+                    row[0] = ct.format("%H:%M:%S%.3f").to_string();
                 }
                 row[1] = format!("{:.3}", row_time_sec);
                 csv_table.push(row);
@@ -114,7 +114,7 @@ impl TableBuilder {
             let first_correlated_time: Option<String> =
                 chunk.correlation_fn.as_ref().and_then(|cf| {
                     cf.correlate(first_time)
-                        .format("%H_%M_%S%.3f")
+                        .format("%Y_%m_%d_%H_%M_%S%_3f")
                         .to_string()
                         .parse()
                         .ok()

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -15,11 +15,15 @@ pub struct TableBuilder {
 impl TableBuilder {
     pub fn new() -> Self {
         Self {
-            bus_row: vec!["".to_string(), "Bus".to_string()],
-            node_row: vec!["".to_string(), "Node".to_string()],
-            message_row: vec!["".to_string(), "Message".to_string()],
-            signal_row: vec!["".to_string(), "Signal".to_string()],
-            next_col_idx: 2, // real time and then daq time columns
+            bus_row: vec!["".to_string(), "".to_string(), "Bus".to_string()],
+            node_row: vec!["".to_string(), "".to_string(), "Node".to_string()],
+            message_row: vec!["".to_string(), "".to_string(), "Message".to_string()],
+            signal_row: vec![
+                "Real Time".to_string(),
+                "DAQ Timestamp".to_string(),
+                "Signal".to_string(),
+            ],
+            next_col_idx: 3, // real time, daq timestamp, then row headers columns
             indexer: std::collections::HashMap::new(),
         }
     }
@@ -120,12 +124,12 @@ impl TableBuilder {
                 Some(t) => out_folder.join(format!("out_{:03}_{}.csv", chunk_idx, t)),
                 None => out_folder.join(format!("out_{:03}.csv", chunk_idx)),
             };
-            let mut wtr = csv::Writer::from_path(out_file).unwrap();
+            let mut wtr = csv::Writer::from_path(out_file.clone()).unwrap();
             for row in csv_table {
                 wtr.write_record(&row).unwrap();
             }
             wtr.flush().unwrap();
-            println!("Wrote chunk {} to CSV", chunk_idx);
+            println!("Wrote chunk {} to CSV ({})", chunk_idx, out_file.display());
         }
     }
 }

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -14,15 +14,14 @@ pub struct TableBuilder {
 
 impl TableBuilder {
     pub fn new() -> Self {
-        let mut tb = Self {
+        Self {
             bus_row: vec!["".to_string(), "Bus".to_string()],
             node_row: vec!["".to_string(), "Node".to_string()],
             message_row: vec!["".to_string(), "Message".to_string()],
             signal_row: vec!["".to_string(), "Signal".to_string()],
             next_col_idx: 2, // real time and then daq time columns
             indexer: std::collections::HashMap::new(),
-        };
-        tb
+        }
     }
 
     pub fn create_header(&mut self, parser: &can_decode::Parser, bus_name: &str) {

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -107,7 +107,16 @@ impl TableBuilder {
                     }
                 }
             }
-            let out_file = out_folder.join(format!("out_{:03}.csv", chunk_idx));
+
+            let first_correlated_time: Option<String> = chunk
+                .correlation_fn
+                .as_ref()
+                .and_then(|cf| cf.correlate(first_time).format("%Y_%m_%d_%H_%M_%S%.3f").to_string().parse().ok());
+
+            let out_file = match first_correlated_time {
+                Some(t) => out_folder.join(format!("out_{:03}_{}.csv", chunk_idx, t)),
+                None => out_folder.join(format!("out_{:03}.csv", chunk_idx)),
+            };
             let mut wtr = csv::Writer::from_path(out_file).unwrap();
             for row in csv_table {
                 wtr.write_record(&row).unwrap();

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -82,7 +82,10 @@ impl TableBuilder {
                 let row_time = first_row_time + row_idx * consts::BIN_WIDTH_MS;
                 let row_time_sec = row_time as f32 / 1000.0;
                 let mut row = vec!["".to_string(); self.bus_row.len()];
-                let correlated_time = chunk.correlation_fn.as_ref().map(|cf| cf.correlate(row_time));
+                let correlated_time = chunk
+                    .correlation_fn
+                    .as_ref()
+                    .map(|cf| cf.correlate(row_time));
                 if let Some(ct) = correlated_time {
                     row[0] = ct.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
                 }
@@ -108,10 +111,14 @@ impl TableBuilder {
                 }
             }
 
-            let first_correlated_time: Option<String> = chunk
-                .correlation_fn
-                .as_ref()
-                .and_then(|cf| cf.correlate(first_time).format("%Y_%m_%d_%H_%M_%S%.3f").to_string().parse().ok());
+            let first_correlated_time: Option<String> =
+                chunk.correlation_fn.as_ref().and_then(|cf| {
+                    cf.correlate(first_time)
+                        .format("%Y_%m_%d_%H_%M_%S%.3f")
+                        .to_string()
+                        .parse()
+                        .ok()
+                });
 
             let out_file = match first_correlated_time {
                 Some(t) => out_folder.join(format!("out_{:03}_{}.csv", chunk_idx, t)),

--- a/src/ui/log_parser.rs
+++ b/src/ui/log_parser.rs
@@ -157,11 +157,12 @@ impl LogParser {
             let parsed =
                 daq_log_parse::parse::parse_log_files(&logs_dir, &parser_bus_0, &parser_bus_1);
             let chunked_parsed = daq_log_parse::parse::chunk_parsed(parsed);
+            let correlated_chunks = daq_log_parse::correlate::time_correlate_chunks(chunked_parsed);
 
             let mut table_builder = daq_log_parse::table::TableBuilder::new();
             table_builder.create_header(&parser_bus_0, "VCAN");
             table_builder.create_header(&parser_bus_1, "MCAN");
-            table_builder.create_and_write_tables(&output_dir, chunked_parsed);
+            table_builder.create_and_write_tables(&output_dir, correlated_chunks);
 
             log::info!("Parsing completed successfully");
             let _ = parse_to_ui_tx.send(MsgFromParserThread::SuccessExit(format!(


### PR DESCRIPTION
- After splitting into chunks, look for all GPS messages
- Linear regression to find correlation between the DAQ timestamp and the time contained in the GPS message
- Added column to the parsed CSV with the "real" (GPS correlated time)
- Log files with valid correlated times are named `out_###_TimeOfFirstMessage`