### PR TITLE
Simple CAN based HIL

### DIFF
--- a/hil_config/presets.json
+++ b/hil_config/presets.json
@@ -1,0 +1,3 @@
+{
+	"Quick sanity check": [ "heartbeats", "idk" ]
+}

--- a/hil_config/presets.json
+++ b/hil_config/presets.json
@@ -1,3 +1,3 @@
 {
-	"Quick sanity check": [ "heartbeats", "idk" ]
+	"All Heartbeats": [ "heartbeats_crit", "heartbeats_non_crit" ]
 }

--- a/hil_config/schema.json
+++ b/hil_config/schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+
+  "required": ["name", "description", "expect"],
+
+  "properties": {
+	"$schema": {
+	  "type": "string"
+	},
+
+    "name": {
+      "type": "string"
+    },
+
+    "description": {
+      "type": "string"
+    },
+
+    "tx": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["timestamp", "msg_name", "signals"],
+
+        "properties": {
+          "timestamp": {
+            "type": "number"
+          },
+
+          "msg_name": {
+            "type": "string"
+          },
+
+          "signals": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    },
+
+    "expect": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["window", "msg_name"],
+
+        "properties": {
+          "window": {
+			"type": "array",
+			"items": {
+			  "type": "number"
+			},
+			"minItems": 2,
+			"maxItems": 2
+		  },
+
+          "msg_name": {
+            "type": "string"
+          },
+
+          "signals": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          }
+        },
+
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false
+}

--- a/hil_config/tests/heartbeats_crit.json
+++ b/hil_config/tests/heartbeats_crit.json
@@ -2,26 +2,24 @@
 	"$schema": "../schema.json",
 
 	"name": "Critical Heartbeats",
-	"description": "Check that we recieve a heartbeat from every drive crtitical board",
+	"description": "Check that we recieve a heartbeat (version hash) from every drive crtitical board",
 
-	"tx": [
-		{
-			"timestamp": 15,
-			"msg_name": "pack_stats",
-			"signals": {
-				"pack_voltage": 540.0,
-				"pack_current": 10.0,
-				"max_temp": 35.0
-			}
-		}
-	],
 	"expect": [
 		{
-			"window": [15, 20],
-			"msg_name": "thermistor_telemetry",
-			"signals": {
-				"temperature": [30.0, 40.0]
-			}
+			"window": [0, 10000],
+			"msg_name": "abox_version"
+		},
+		{
+			"window": [0, 10000],
+			"msg_name": "dash_version"
+		},
+		{
+			"window": [0, 10000],
+			"msg_name": "main_version"
+		},
+		{
+			"window": [0, 10000],
+			"msg_name": "pdu_version"
 		}
 	]
 }

--- a/hil_config/tests/heartbeats_crit.json
+++ b/hil_config/tests/heartbeats_crit.json
@@ -2,7 +2,7 @@
 	"$schema": "../schema.json",
 
 	"name": "Critical Heartbeats",
-	"description": "Check that we receive a heartbeat (version hash) from every drive crtitical board",
+	"description": "Check that we receive a heartbeat (version hash) from every drive critical board",
 
 	"expect": [
 		{

--- a/hil_config/tests/heartbeats_crit.json
+++ b/hil_config/tests/heartbeats_crit.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "../schema.json",
+
+	"name": "Critical Heartbeats",
+	"description": "Check that we recieve a heartbeat from every drive crtitical board",
+
+	"tx": [
+		{
+			"timestamp": 15,
+			"msg_name": "pack_stats",
+			"signals": {
+				"pack_voltage": 540.0,
+				"pack_current": 10.0,
+				"max_temp": 35.0
+			}
+		}
+	],
+	"expect": [
+		{
+			"window": [15, 20],
+			"msg_name": "thermistor_telemetry",
+			"signals": {
+				"temperature": [30.0, 40.0]
+			}
+		}
+	]
+}

--- a/hil_config/tests/heartbeats_crit.json
+++ b/hil_config/tests/heartbeats_crit.json
@@ -2,7 +2,7 @@
 	"$schema": "../schema.json",
 
 	"name": "Critical Heartbeats",
-	"description": "Check that we recieve a heartbeat (version hash) from every drive crtitical board",
+	"description": "Check that we receive a heartbeat (version hash) from every drive crtitical board",
 
 	"expect": [
 		{

--- a/hil_config/tests/heartbeats_non_crit.json
+++ b/hil_config/tests/heartbeats_non_crit.json
@@ -2,26 +2,16 @@
 	"$schema": "../schema.json",
 
 	"name": "Non-Critical Heartbeats",
-	"description": "Check that we recieve a heartbeat from every non-critical board",
+	"description": "Check that we recieve a heartbeat (version hash) from non-critical boards",
 
-	"tx": [
-		{
-			"timestamp": 15,
-			"msg_name": "pack_stats",
-			"signals": {
-				"pack_voltage": 540.0,
-				"pack_current": 10.0,
-				"max_temp": 35.0
-			}
-		}
-	],
 	"expect": [
 		{
-			"window": [15, 20],
-			"msg_name": "thermistor_telemetry",
-			"signals": {
-				"temperature": [30.0, 40.0]
-			}
+			"window": [0, 10000],
+			"msg_name": "front_driveline_version"
+		},
+		{
+			"window": [0, 10000],
+			"msg_name": "rear_driveline_version"
 		}
 	]
 }

--- a/hil_config/tests/heartbeats_non_crit.json
+++ b/hil_config/tests/heartbeats_non_crit.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "../schema.json",
+
+	"name": "Critical Heartbeats",
+	"description": "Check that we recieve a heartbeat from every drive crtitical board",
+
+	"tx": [
+		{
+			"timestamp": 15,
+			"msg_name": "pack_stats",
+			"signals": {
+				"pack_voltage": 540.0,
+				"pack_current": 10.0,
+				"max_temp": 35.0
+			}
+		}
+	],
+	"expect": [
+		{
+			"window": [15, 20],
+			"msg_name": "thermistor_telemetry",
+			"signals": {
+				"temperature": [30.0, 40.0]
+			}
+		}
+	]
+}

--- a/hil_config/tests/heartbeats_non_crit.json
+++ b/hil_config/tests/heartbeats_non_crit.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "../schema.json",
 
-	"name": "Critical Heartbeats",
-	"description": "Check that we recieve a heartbeat from every drive crtitical board",
+	"name": "Non-Critical Heartbeats",
+	"description": "Check that we recieve a heartbeat from every non-critical board",
 
 	"tx": [
 		{

--- a/hil_config/tests/heartbeats_non_crit.json
+++ b/hil_config/tests/heartbeats_non_crit.json
@@ -2,7 +2,7 @@
 	"$schema": "../schema.json",
 
 	"name": "Non-Critical Heartbeats",
-	"description": "Check that we recieve a heartbeat (version hash) from non-critical boards",
+	"description": "Check that we receive a heartbeat (version hash) from non-critical boards",
 
 	"expect": [
 		{

--- a/hil_config/tests/idk.json
+++ b/hil_config/tests/idk.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "../schema.json",
+
 	"name": "Pack sanity check",
 	"description": "Verify thermistor response",
 

--- a/hil_config/tests/idk.json
+++ b/hil_config/tests/idk.json
@@ -1,0 +1,25 @@
+{
+	"name": "Pack sanity check",
+	"description": "Verify thermistor response",
+
+	"tx": [
+		{
+			"timestamp": 15,
+			"msg_name": "pack_stats",
+			"signals": {
+				"pack_voltage": 540.0,
+				"pack_current": 10.0,
+				"max_temp": 35.0
+			}
+		}
+	],
+	"expect": [
+		{
+			"window": [15, 20],
+			"msg_name": "thermistor_telemetry",
+			"signals": {
+				"temperature": [30.0, 40.0]
+			}
+		}
+	]
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -56,6 +56,10 @@ impl AppAction {
                 "Spawn Jitter",
                 widget_constructor::WidgetConstructor::Jitter,
             ),
+            (
+                "Spawn HIL",
+                widget_constructor::WidgetConstructor::Hil
+            ),
         ]
     }
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -56,10 +56,7 @@ impl AppAction {
                 "Spawn Jitter",
                 widget_constructor::WidgetConstructor::Jitter,
             ),
-            (
-                "Spawn HIL",
-                widget_constructor::WidgetConstructor::Hil
-            ),
+            ("Spawn HIL", widget_constructor::WidgetConstructor::Hil),
         ]
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,18 +39,7 @@ pub struct DAQApp {
     pub is_sidebar_open: bool,
     pub command_palette: ui::command_palette::CommandPalette,
     pub tile_tree: egui_tiles::Tree<widgets::Widget>,
-    pub next_can_viewer_num: usize,
-    pub next_can_list_num: usize,
-    pub next_bootloader_num: usize,
-    pub next_scope_num: usize,
-    pub next_log_parser_num: usize,
-    pub next_send_ui_num: usize,
-    pub next_bus_load_num: usize,
-    pub next_battery_voltage_num: usize,
-    pub next_battery_temps_num: usize,
-    pub next_gg_plot_num: usize,
-    pub next_dynamics_num: usize,
-    pub next_jitter_num: usize,
+    pub widget_ids: widget_ids::WidgetIds,
     pub can_to_ui_rx: std::sync::mpsc::Receiver<messages::MsgFromCan>,
     pub ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
     pub action_queue: Vec<action::AppAction>,
@@ -95,23 +84,7 @@ impl DAQApp {
             is_sidebar_open: true,
             command_palette: ui::command_palette::CommandPalette::new(),
             tile_tree: egui_tiles::Tree::empty("workspace_tree"),
-<<<<<<< HEAD
             widget_ids: widget_ids::WidgetIds::new(),
-=======
-            next_can_viewer_num: 1,
-            next_can_list_num: 1,
-            next_bootloader_num: 1,
-            next_scope_num: 1,
-            next_log_parser_num: 1,
-            next_send_ui_num: 1,
-            next_bus_load_num: 1,
-            next_battery_voltage_num: 1,
-            next_battery_temps_num: 1,
-            next_gg_plot_num: 1,
-            next_dynamics_num: 1,
-            next_jitter_num: 1,
-            next_hil_num: 1,
->>>>>>> 88fbf06 (Wiring HIL widget + trying to think about UI state)
             can_to_ui_rx,
             ui_to_can_tx,
             action_queue: Vec::new(),
@@ -169,106 +142,8 @@ impl DAQApp {
     pub fn handle_action(&mut self, action: action::AppAction, ctx: &egui::Context) {
         match action {
             action::AppAction::SpawnWidget(widget_type) => {
-<<<<<<< HEAD
                 let widget = widget_type.create(&mut self.widget_ids, self.ui_to_can_tx.clone());
                 self.add_widget_to_tree(widget);
-=======
-                let widget = match &widget_type {
-                    action::WidgetType::ViewerTable => widgets::Widget::ViewerTable(
-                        ui::viewer_table::ViewerTable::new(self.next_can_viewer_num),
-                    ),
-                    action::WidgetType::ViewerList => widgets::Widget::ViewerList(
-                        ui::viewer_list::ViewerList::new(self.next_can_list_num),
-                    ),
-                    action::WidgetType::Bootloader => widgets::Widget::Bootloader(
-                        ui::bootloader::Bootloader::new(self.next_bootloader_num),
-                    ),
-                    action::WidgetType::Scope {
-                        msg_id,
-                        msg_name,
-                        signal_name,
-                    } => widgets::Widget::Scope(ui::scope::Scope::new(
-                        self.next_scope_num,
-                        *msg_id,
-                        msg_name.clone(),
-                        signal_name.clone(),
-                    )),
-                    action::WidgetType::LogParser => widgets::Widget::LogParser(
-                        ui::log_parser::LogParser::new(self.next_log_parser_num),
-                    ),
-                    action::WidgetType::SendUi => widgets::Widget::SendUi(ui::send::SendUi::new(
-                        self.next_send_ui_num,
-                        self.ui_to_can_tx.clone(),
-                    )),
-                    action::WidgetType::BusLoad => {
-                        widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.next_bus_load_num))
-                    }
-                    action::WidgetType::BatteryVoltage => widgets::Widget::BatteryVoltage(
-                        ui::battery::battery_voltage::BatteryVoltage::new(
-                            self.next_battery_voltage_num,
-                        ),
-                    ),
-                    action::WidgetType::BatteryTemps => widgets::Widget::BatteryTemps(
-                        ui::battery::battery_temps::BatteryTemps::new(self.next_battery_temps_num),
-                    ),
-                    action::WidgetType::GgPlot => {
-                        widgets::Widget::GgPlot(ui::gg_plot::GgPlot::new(self.next_gg_plot_num))
-                    }
-                    action::WidgetType::Dynamics => widgets::Widget::Dynamics(
-                        ui::dynamics::Dynamics::new(self.next_dynamics_num),
-                    ),
-                    action::WidgetType::Jitter => {
-                        widgets::Widget::Jitter(ui::jitter::Jitter::new(self.next_jitter_num))
-                    }
-                    action::WidgetType::Hil => {
-                        widgets::Widget::Hil(ui::hil::Hil::new(self.next_hil_num))
-                    }
-                };
-                self.add_widget_to_tree(widget);
-
-                // Increment the appropriate counter
-                match widget_type {
-                    action::WidgetType::ViewerTable => {
-                        self.next_can_viewer_num += 1;
-                    }
-                    action::WidgetType::ViewerList => {
-                        self.next_can_list_num += 1;
-                    }
-                    action::WidgetType::Bootloader => {
-                        self.next_bootloader_num += 1;
-                    }
-                    action::WidgetType::Scope { .. } => {
-                        self.next_scope_num += 1;
-                    }
-                    action::WidgetType::LogParser => {
-                        self.next_log_parser_num += 1;
-                    }
-                    action::WidgetType::SendUi => {
-                        self.next_send_ui_num += 1;
-                    }
-                    action::WidgetType::BusLoad => {
-                        self.next_bus_load_num += 1;
-                    }
-                    action::WidgetType::BatteryVoltage => {
-                        self.next_battery_voltage_num += 1;
-                    }
-                    action::WidgetType::BatteryTemps => {
-                        self.next_battery_temps_num += 1;
-                    }
-                    action::WidgetType::GgPlot => {
-                        self.next_gg_plot_num += 1;
-                    }
-                    action::WidgetType::Dynamics => {
-                        self.next_dynamics_num += 1;
-                    }
-                    action::WidgetType::Jitter => {
-                        self.next_jitter_num += 1;
-                    }
-                    action::WidgetType::Hil => {
-                        self.next_hil_num += 1;
-                    }
-                }
->>>>>>> 88fbf06 (Wiring HIL widget + trying to think about UI state)
             }
             action::AppAction::ToggleSidebar => {
                 self.is_sidebar_open = !self.is_sidebar_open;

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,7 +39,18 @@ pub struct DAQApp {
     pub is_sidebar_open: bool,
     pub command_palette: ui::command_palette::CommandPalette,
     pub tile_tree: egui_tiles::Tree<widgets::Widget>,
-    pub widget_ids: widget_ids::WidgetIds,
+    pub next_can_viewer_num: usize,
+    pub next_can_list_num: usize,
+    pub next_bootloader_num: usize,
+    pub next_scope_num: usize,
+    pub next_log_parser_num: usize,
+    pub next_send_ui_num: usize,
+    pub next_bus_load_num: usize,
+    pub next_battery_voltage_num: usize,
+    pub next_battery_temps_num: usize,
+    pub next_gg_plot_num: usize,
+    pub next_dynamics_num: usize,
+    pub next_jitter_num: usize,
     pub can_to_ui_rx: std::sync::mpsc::Receiver<messages::MsgFromCan>,
     pub ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
     pub action_queue: Vec<action::AppAction>,
@@ -84,7 +95,23 @@ impl DAQApp {
             is_sidebar_open: true,
             command_palette: ui::command_palette::CommandPalette::new(),
             tile_tree: egui_tiles::Tree::empty("workspace_tree"),
+<<<<<<< HEAD
             widget_ids: widget_ids::WidgetIds::new(),
+=======
+            next_can_viewer_num: 1,
+            next_can_list_num: 1,
+            next_bootloader_num: 1,
+            next_scope_num: 1,
+            next_log_parser_num: 1,
+            next_send_ui_num: 1,
+            next_bus_load_num: 1,
+            next_battery_voltage_num: 1,
+            next_battery_temps_num: 1,
+            next_gg_plot_num: 1,
+            next_dynamics_num: 1,
+            next_jitter_num: 1,
+            next_hil_num: 1,
+>>>>>>> 88fbf06 (Wiring HIL widget + trying to think about UI state)
             can_to_ui_rx,
             ui_to_can_tx,
             action_queue: Vec::new(),
@@ -142,8 +169,106 @@ impl DAQApp {
     pub fn handle_action(&mut self, action: action::AppAction, ctx: &egui::Context) {
         match action {
             action::AppAction::SpawnWidget(widget_type) => {
+<<<<<<< HEAD
                 let widget = widget_type.create(&mut self.widget_ids, self.ui_to_can_tx.clone());
                 self.add_widget_to_tree(widget);
+=======
+                let widget = match &widget_type {
+                    action::WidgetType::ViewerTable => widgets::Widget::ViewerTable(
+                        ui::viewer_table::ViewerTable::new(self.next_can_viewer_num),
+                    ),
+                    action::WidgetType::ViewerList => widgets::Widget::ViewerList(
+                        ui::viewer_list::ViewerList::new(self.next_can_list_num),
+                    ),
+                    action::WidgetType::Bootloader => widgets::Widget::Bootloader(
+                        ui::bootloader::Bootloader::new(self.next_bootloader_num),
+                    ),
+                    action::WidgetType::Scope {
+                        msg_id,
+                        msg_name,
+                        signal_name,
+                    } => widgets::Widget::Scope(ui::scope::Scope::new(
+                        self.next_scope_num,
+                        *msg_id,
+                        msg_name.clone(),
+                        signal_name.clone(),
+                    )),
+                    action::WidgetType::LogParser => widgets::Widget::LogParser(
+                        ui::log_parser::LogParser::new(self.next_log_parser_num),
+                    ),
+                    action::WidgetType::SendUi => widgets::Widget::SendUi(ui::send::SendUi::new(
+                        self.next_send_ui_num,
+                        self.ui_to_can_tx.clone(),
+                    )),
+                    action::WidgetType::BusLoad => {
+                        widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.next_bus_load_num))
+                    }
+                    action::WidgetType::BatteryVoltage => widgets::Widget::BatteryVoltage(
+                        ui::battery::battery_voltage::BatteryVoltage::new(
+                            self.next_battery_voltage_num,
+                        ),
+                    ),
+                    action::WidgetType::BatteryTemps => widgets::Widget::BatteryTemps(
+                        ui::battery::battery_temps::BatteryTemps::new(self.next_battery_temps_num),
+                    ),
+                    action::WidgetType::GgPlot => {
+                        widgets::Widget::GgPlot(ui::gg_plot::GgPlot::new(self.next_gg_plot_num))
+                    }
+                    action::WidgetType::Dynamics => widgets::Widget::Dynamics(
+                        ui::dynamics::Dynamics::new(self.next_dynamics_num),
+                    ),
+                    action::WidgetType::Jitter => {
+                        widgets::Widget::Jitter(ui::jitter::Jitter::new(self.next_jitter_num))
+                    }
+                    action::WidgetType::Hil => {
+                        widgets::Widget::Hil(ui::hil::Hil::new(self.next_hil_num))
+                    }
+                };
+                self.add_widget_to_tree(widget);
+
+                // Increment the appropriate counter
+                match widget_type {
+                    action::WidgetType::ViewerTable => {
+                        self.next_can_viewer_num += 1;
+                    }
+                    action::WidgetType::ViewerList => {
+                        self.next_can_list_num += 1;
+                    }
+                    action::WidgetType::Bootloader => {
+                        self.next_bootloader_num += 1;
+                    }
+                    action::WidgetType::Scope { .. } => {
+                        self.next_scope_num += 1;
+                    }
+                    action::WidgetType::LogParser => {
+                        self.next_log_parser_num += 1;
+                    }
+                    action::WidgetType::SendUi => {
+                        self.next_send_ui_num += 1;
+                    }
+                    action::WidgetType::BusLoad => {
+                        self.next_bus_load_num += 1;
+                    }
+                    action::WidgetType::BatteryVoltage => {
+                        self.next_battery_voltage_num += 1;
+                    }
+                    action::WidgetType::BatteryTemps => {
+                        self.next_battery_temps_num += 1;
+                    }
+                    action::WidgetType::GgPlot => {
+                        self.next_gg_plot_num += 1;
+                    }
+                    action::WidgetType::Dynamics => {
+                        self.next_dynamics_num += 1;
+                    }
+                    action::WidgetType::Jitter => {
+                        self.next_jitter_num += 1;
+                    }
+                    action::WidgetType::Hil => {
+                        self.next_hil_num += 1;
+                    }
+                }
+>>>>>>> 88fbf06 (Wiring HIL widget + trying to think about UI state)
             }
             action::AppAction::ToggleSidebar => {
                 self.is_sidebar_open = !self.is_sidebar_open;

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -60,24 +60,38 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
     let mut individual_tests = Vec::new();
     if let Ok(entries) = std::fs::read_dir(TESTS_FOLDER) {
         for entry in entries.flatten() {
-            if let Ok(content) = std::fs::read_to_string(entry.path()) {
-                if let Ok(test_data) = serde_json::from_str::<TestFile>(&content) {
-                    individual_tests.push(TestInfo {
-                        basename: entry
-                            .path()
-                            .file_stem()
-                            .unwrap_or_default()
-                            .to_string_lossy()
-                            .to_string(),
-                        name: test_data.name,
-                        description: test_data.description,
-                    });
-                } else {
-                    errors.push(format!("Failed to parse test file: {:?}", entry.path()));
-                }
-            } else {
-                errors.push(format!("Failed to read test file: {:?}", entry.path()));
+            let path = entry.path();
+            if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
             }
+
+            let basename = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(stem) if !stem.is_empty() => stem.to_string(),
+                _ => {
+                    errors.push(format!(
+                        "Failed to determine test basename for file: {:?}",
+                        path
+                    ));
+                    continue;
+                }
+            };
+
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => {
+                    errors.push(format!("Failed to read test file: {:?}", path));
+                    continue;
+                }
+            };
+
+            match serde_json::from_str::<TestFile>(&content) {
+                Ok(test_data) => individual_tests.push(TestInfo {
+                    basename,
+                    name: test_data.name,
+                    description: test_data.description,
+                }),
+                Err(_) => errors.push(format!("Failed to parse test file: {:?}", path)),
+            };
         }
     } else {
         errors.push(format!("Failed to read tests directory: {}", TESTS_FOLDER));

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -1,0 +1,37 @@
+// Read HIL config files (preset and tests)
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PresetsFile(pub HashMap<String, Vec<String>>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestFile {
+    pub name: String,
+    pub description: String,
+
+    #[serde(default)]
+    pub tx: Vec<TxMessage>,
+
+    pub expect: Vec<Expectation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxMessage {
+    pub timestamp: f64,
+    pub msg_name: String,
+
+    pub signals: HashMap<String, f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Expectation {
+    pub window: [f64; 2],
+
+    pub msg_name: String,
+
+    #[serde(default)]
+    pub signals: HashMap<String, [f64; 2]>,
+}

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -82,6 +82,7 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
     } else {
         errors.push(format!("Failed to read tests directory: {}", TESTS_FOLDER));
     }
+    individual_tests.sort_by(|a, b| a.basename.to_lowercase().cmp(&b.basename.to_lowercase()));
 
     // Load presets
     let mut presets = Vec::new();
@@ -127,6 +128,7 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
     } else {
         errors.push(format!("Failed to read presets file: {}", PRESETS_FILE));
     }
+    presets.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
 
     (presets, individual_tests, errors)
 }

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -3,8 +3,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub const PRESETS_FILE: &str = "../../hil_config/presets.json";
-pub const TESTS_FOLDER: &str = "../../hil_config/tests/";
+pub const PRESETS_FILE: &str = "hil_config/presets.json";
+pub const TESTS_FOLDER: &str = "hil_config/tests/";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -60,7 +60,12 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
             if let Ok(content) = std::fs::read_to_string(entry.path()) {
                 if let Ok(test_data) = serde_json::from_str::<TestFile>(&content) {
                     individual_tests.push(TestInfo {
-                        basename: entry.file_name().to_string_lossy().to_string(),
+                        basename: entry
+                            .path()
+                            .file_stem()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string(),
                         name: test_data.name,
                         description: test_data.description,
                     });
@@ -71,6 +76,8 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
                 errors.push(format!("Failed to read test file: {:?}", entry.path()));
             }
         }
+    } else {
+        errors.push(format!("Failed to read tests directory: {}", TESTS_FOLDER));
     }
 
     // Load presets

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -3,6 +3,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub const PRESETS_FILE: &str = "../../hil_config/presets.json";
+pub const TESTS_FOLDER: &str = "../../hil_config/tests/";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PresetsFile(pub HashMap<String, Vec<String>>);
@@ -34,4 +37,86 @@ pub struct Expectation {
 
     #[serde(default)]
     pub signals: HashMap<String, [f64; 2]>,
+}
+
+pub struct PresetInfo {
+    pub name: String,
+    pub subtests: Vec<String>,
+}
+
+pub struct TestInfo {
+    pub basename: String,
+    pub name: String,
+    pub description: String,
+}
+
+pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
+    let mut errors = Vec::new();
+
+    // Load individual tests
+    let mut individual_tests = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(TESTS_FOLDER) {
+        for entry in entries.flatten() {
+            if let Ok(content) = std::fs::read_to_string(entry.path()) {
+                if let Ok(test_data) = serde_json::from_str::<TestFile>(&content) {
+                    individual_tests.push(TestInfo {
+                        basename: entry.file_name().to_string_lossy().to_string(),
+                        name: test_data.name,
+                        description: test_data.description,
+                    });
+                } else {
+                    errors.push(format!("Failed to parse test file: {:?}", entry.path()));
+                }
+            } else {
+                errors.push(format!("Failed to read test file: {:?}", entry.path()));
+            }
+        }
+    }
+
+    // Load presets
+    let mut presets = Vec::new();
+    if let Ok(presets_file) = std::fs::read_to_string(PRESETS_FILE) {
+        if let Ok(presets_data) = serde_json::from_str::<PresetsFile>(&presets_file) {
+            for (preset_name, subtests) in presets_data.0 {
+                if subtests.is_empty() {
+                    errors.push(format!("Preset '{}' has no subtests defined", preset_name));
+                    continue;
+                }
+
+                if subtests.iter().any(|s| s.trim().is_empty()) {
+                    errors.push(format!(
+                        "Preset '{}' contains empty subtest names",
+                        preset_name
+                    ));
+                    continue;
+                }
+
+                if subtests
+                    .iter()
+                    .any(|s| individual_tests.iter().all(|t| t.basename != *s))
+                {
+                    errors.push(format!(
+                        "Preset '{}' contains subtests that do not exist: {:?}",
+                        preset_name,
+                        subtests
+                            .iter()
+                            .filter(|s| individual_tests.iter().all(|t| t.basename != **s))
+                            .collect::<Vec<_>>()
+                    ));
+                    continue;
+                }
+
+                presets.push(PresetInfo {
+                    name: preset_name,
+                    subtests,
+                });
+            }
+        } else {
+            errors.push(format!("Failed to parse presets file: {}", PRESETS_FILE));
+        }
+    } else {
+        errors.push(format!("Failed to read presets file: {}", PRESETS_FILE));
+    }
+
+    (presets, individual_tests, errors)
 }

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -41,9 +41,11 @@ pub struct Expectation {
 
 pub struct PresetInfo {
     pub name: String,
-    pub subtests: Vec<String>,
+    // base names
+    pub tests: Vec<String>,
 }
 
+#[derive(Clone)]
 pub struct TestInfo {
     pub basename: String,
     pub name: String,
@@ -115,7 +117,7 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
 
                 presets.push(PresetInfo {
                     name: preset_name,
-                    subtests,
+                    tests: subtests,
                 });
             }
         } else {
@@ -126,4 +128,15 @@ pub fn list_available_tests() -> (Vec<PresetInfo>, Vec<TestInfo>, Vec<String>) {
     }
 
     (presets, individual_tests, errors)
+}
+
+pub fn load_test_from_file(basename: &str) -> Result<TestFile, String> {
+    let path = format!("{}{}.json", TESTS_FOLDER, basename);
+    match std::fs::read_to_string(&path) {
+        Ok(content) => match serde_json::from_str::<TestFile>(&content) {
+            Ok(test_data) => Ok(test_data),
+            Err(_) => Err(format!("Failed to parse test file: {}", path)),
+        },
+        Err(_) => Err(format!("Failed to read test file: {}", path)),
+    }
 }

--- a/src/hil/config.rs
+++ b/src/hil/config.rs
@@ -39,6 +39,7 @@ pub struct Expectation {
     pub signals: HashMap<String, [f64; 2]>,
 }
 
+#[derive(Clone)]
 pub struct PresetInfo {
     pub name: String,
     // base names

--- a/src/hil/mod.rs
+++ b/src/hil/mod.rs
@@ -1,0 +1,1 @@
+mod config;

--- a/src/hil/mod.rs
+++ b/src/hil/mod.rs
@@ -1,1 +1,2 @@
-mod config;
+pub mod config;
+pub mod run;

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -36,14 +36,16 @@ impl HilRunningTest {
             name: test_info.name.clone(),
             description: test_info.description.clone(),
             tx_remaining: test.tx,
-            in_progress_expects: test
-                .expect
-                .into_iter()
-                .map(|expect| InProgressExpect {
-                    expect,
-                    result: ExpectResult::NotInWindow,
-                })
-                .collect(),
+            in_progress_expects: test.expect.into_iter().map(InProgressExpect::new).collect(),
         })
+    }
+}
+
+impl InProgressExpect {
+    pub fn new(expect: hil::config::Expectation) -> Self {
+        Self {
+            expect,
+            result: ExpectResult::NotInWindow,
+        }
     }
 }

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -1,3 +1,5 @@
+use eframe::egui;
+
 use crate::hil::{self, config};
 
 pub enum ExpectResult {
@@ -38,6 +40,17 @@ impl ExpectResult {
             ExpectResult::Passed => "Passed",
             ExpectResult::FailedNoMessage => "Failed (no message)",
             ExpectResult::FailedValueOutOfRange => "Failed (value out of range)",
+        }
+    }
+
+    pub fn as_color32(&self) -> egui::Color32 {
+        match self {
+            ExpectResult::NotInWindow => egui::Color32::GRAY,
+            ExpectResult::InProgress => egui::Color32::YELLOW,
+            ExpectResult::Passed => egui::Color32::GREEN,
+            ExpectResult::FailedNoMessage | ExpectResult::FailedValueOutOfRange => {
+                egui::Color32::RED
+            }
         }
     }
 

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -16,9 +16,7 @@ pub struct InProgressExpect {
 }
 
 pub struct HilRunningTest {
-    pub name: String,
-    pub description: String,
-
+    pub test_info: hil::config::TestInfo,
     pub tx_remaining: Vec<hil::config::TxMessage>,
     pub in_progress_expects: Vec<InProgressExpect>,
 }
@@ -75,8 +73,7 @@ impl HilRunningTest {
         in_progress_expects
             .sort_by(|a, b| a.expect.window[0].partial_cmp(&b.expect.window[0]).unwrap());
         Ok(Self {
-            name: test_info.name.clone(),
-            description: test_info.description.clone(),
+            test_info: test_info.clone(),
             tx_remaining: test.tx,
             in_progress_expects,
         })
@@ -96,6 +93,12 @@ impl HilRunningTest {
         }
 
         (not_in_window, in_progress, completed)
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.in_progress_expects
+            .iter()
+            .all(|e| e.result.is_finished())
     }
 }
 

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -80,7 +80,7 @@ impl HilRunningTest {
         })
     }
 
-    fn update_expect_statuses(&mut self, start_time: std::time::Instant) {
+    pub fn update_expect_statuses(&mut self, start_time: std::time::Instant) {
         let ts = start_time.elapsed().as_millis();
         for expect in &mut self.in_progress_expects {
             match expect.result {

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -71,8 +71,7 @@ impl HilRunningTest {
             .into_iter()
             .map(InProgressExpect::new)
             .collect::<Vec<_>>();
-        in_progress_expects
-            .sort_by(|a, b| a.expect.window[0].partial_cmp(&b.expect.window[0]).unwrap());
+        in_progress_expects.sort_by(|a, b| a.expect.window[0].total_cmp(&b.expect.window[0]));
         Ok(Self {
             test_info: test_info.clone(),
             tx_remaining: test.tx,

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -1,7 +1,8 @@
 use eframe::egui;
 
-use crate::hil::{self, config};
+use crate::{hil, messages};
 
+#[derive(PartialEq, Eq)]
 pub enum ExpectResult {
     NotInWindow,
     InProgress,
@@ -79,6 +80,63 @@ impl HilRunningTest {
         })
     }
 
+    fn update_expect_statuses(&mut self, start_time: std::time::Instant) {
+        let ts = start_time.elapsed().as_millis();
+        for expect in &mut self.in_progress_expects {
+            match expect.result {
+                ExpectResult::NotInWindow => {
+                    if ts >= expect.expect.window[0] as u128 {
+                        expect.result = ExpectResult::InProgress;
+                    }
+                }
+                ExpectResult::InProgress => {
+                    if ts > expect.expect.window[1] as u128 {
+                        expect.result = ExpectResult::FailedNoMessage;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub fn process_can(
+        &mut self,
+        parsed: &messages::ParsedMessage,
+        start_time: std::time::Instant,
+    ) {
+        self.update_expect_statuses(start_time);
+
+        for expect in &mut self.in_progress_expects {
+            if expect.result == ExpectResult::InProgress && expect.matches_message(&parsed.decoded)
+            {
+                if expect.expect.signals.is_empty() {
+                    expect.result = ExpectResult::Passed;
+                } else {
+                    let mut all_signals_in_range = true;
+                    for (sig_name, sig_range) in &expect.expect.signals {
+                        if let Some(sig_value) = parsed.decoded.signals.get(sig_name) {
+                            if sig_value.value.physical < sig_range[0]
+                                || sig_value.value.physical > sig_range[1]
+                            {
+                                all_signals_in_range = false;
+                                break;
+                            }
+                        } else {
+                            all_signals_in_range = false;
+                            break;
+                        }
+                    }
+
+                    expect.result = if all_signals_in_range {
+                        ExpectResult::Passed
+                    } else {
+                        ExpectResult::FailedValueOutOfRange
+                    };
+                }
+            }
+        }
+    }
+
     pub fn expect_counts(&self) -> (usize, usize, usize) {
         let mut not_in_window = 0;
         let mut in_progress = 0;
@@ -108,5 +166,9 @@ impl InProgressExpect {
             expect,
             result: ExpectResult::NotInWindow,
         }
+    }
+
+    pub fn matches_message(&self, decoded: &can_decode::DecodedMessage) -> bool {
+        self.expect.msg_name == decoded.name
     }
 }

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -4,7 +4,8 @@ pub enum ExpectResult {
     NotInWindow,
     InProgress,
     Passed,
-    Failed,
+    FailedNoMessage,
+    FailedValueOutOfRange,
 }
 
 pub struct InProgressExpect {
@@ -35,8 +36,18 @@ impl ExpectResult {
             ExpectResult::NotInWindow => "Not in window",
             ExpectResult::InProgress => "In progress",
             ExpectResult::Passed => "Passed",
-            ExpectResult::Failed => "Failed",
+            ExpectResult::FailedNoMessage => "Failed (no message)",
+            ExpectResult::FailedValueOutOfRange => "Failed (value out of range)",
         }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        matches!(
+            self,
+            ExpectResult::Passed
+                | ExpectResult::FailedNoMessage
+                | ExpectResult::FailedValueOutOfRange
+        )
     }
 }
 
@@ -67,7 +78,7 @@ impl HilRunningTest {
             match expect.result {
                 ExpectResult::NotInWindow => not_in_window += 1,
                 ExpectResult::InProgress => in_progress += 1,
-                ExpectResult::Passed | ExpectResult::Failed => completed += 1,
+                _ => completed += 1,
             }
         }
 

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -1,4 +1,4 @@
-use crate::hil;
+use crate::hil::{self, config};
 
 pub enum ExpectResult {
     NotInWindow,
@@ -17,7 +17,7 @@ pub struct HilRunningTest {
     pub description: String,
 
     pub tx_remaining: Vec<hil::config::TxMessage>,
-    pub expect: Vec<hil::config::Expectation>,
+    pub in_progress_expects: Vec<InProgressExpect>,
 }
 
 pub enum HilState {
@@ -27,4 +27,23 @@ pub enum HilState {
         preset_name: Option<String>,
         tests: Vec<HilRunningTest>,
     },
+}
+
+impl HilRunningTest {
+    pub fn new(test_info: &hil::config::TestInfo) -> Result<Self, String> {
+        let test = hil::config::load_test_from_file(&test_info.basename)?;
+        Ok(Self {
+            name: test_info.name.clone(),
+            description: test_info.description.clone(),
+            tx_remaining: test.tx,
+            in_progress_expects: test
+                .expect
+                .into_iter()
+                .map(|expect| InProgressExpect {
+                    expect,
+                    result: ExpectResult::NotInWindow,
+                })
+                .collect(),
+        })
+    }
 }

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -1,0 +1,30 @@
+use crate::hil;
+
+pub enum ExpectResult {
+    NotInWindow,
+    InProgress,
+    Passed,
+    Failed,
+}
+
+pub struct InProgressExpect {
+    pub expect: hil::config::Expectation,
+    pub result: ExpectResult,
+}
+
+pub struct HilRunningTest {
+    pub name: String,
+    pub description: String,
+
+    pub tx_remaining: Vec<hil::config::TxMessage>,
+    pub expect: Vec<hil::config::Expectation>,
+}
+
+pub enum HilState {
+    Idle,
+    Running {
+        start_time: std::time::Instant,
+        preset_name: Option<String>,
+        tests: Vec<HilRunningTest>,
+    },
+}

--- a/src/hil/run.rs
+++ b/src/hil/run.rs
@@ -24,20 +24,54 @@ pub enum HilState {
     Idle,
     Running {
         start_time: std::time::Instant,
-        preset_name: Option<String>,
+        preset_info: Option<hil::config::PresetInfo>,
         tests: Vec<HilRunningTest>,
     },
+}
+
+impl ExpectResult {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExpectResult::NotInWindow => "Not in window",
+            ExpectResult::InProgress => "In progress",
+            ExpectResult::Passed => "Passed",
+            ExpectResult::Failed => "Failed",
+        }
+    }
 }
 
 impl HilRunningTest {
     pub fn new(test_info: &hil::config::TestInfo) -> Result<Self, String> {
         let test = hil::config::load_test_from_file(&test_info.basename)?;
+        let mut in_progress_expects = test
+            .expect
+            .into_iter()
+            .map(InProgressExpect::new)
+            .collect::<Vec<_>>();
+        in_progress_expects
+            .sort_by(|a, b| a.expect.window[0].partial_cmp(&b.expect.window[0]).unwrap());
         Ok(Self {
             name: test_info.name.clone(),
             description: test_info.description.clone(),
             tx_remaining: test.tx,
-            in_progress_expects: test.expect.into_iter().map(InProgressExpect::new).collect(),
+            in_progress_expects,
         })
+    }
+
+    pub fn expect_counts(&self) -> (usize, usize, usize) {
+        let mut not_in_window = 0;
+        let mut in_progress = 0;
+        let mut completed = 0;
+
+        for expect in &self.in_progress_expects {
+            match expect.result {
+                ExpectResult::NotInWindow => not_in_window += 1,
+                ExpectResult::InProgress => in_progress += 1,
+                ExpectResult::Passed | ExpectResult::Failed => completed += 1,
+            }
+        }
+
+        (not_in_window, in_progress, completed)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod connection;
 mod daq_log_parse;
 mod formatter;
 mod frozen;
+mod hil;
 mod messages;
 mod settings;
 mod shortcuts;

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -130,8 +130,8 @@ impl Hil {
             } => {
                 let time_since_start = start_time.elapsed().as_secs_f64();
                 ui.label(format!(
-                    "HIL is running... {:.2} seconds since start",
-                    time_since_start
+                    "HIL is running... {:.0} ms since start",
+                    time_since_start * 1000.0
                 ));
                 ui.separator();
 
@@ -157,15 +157,17 @@ impl Hil {
                     ));
 
                     for ipe in &test.in_progress_expects {
-                        let status = ipe.result.as_str();
                         ui.label(format!(
-                            "Expect: {} [{} - {}] - {}",
-                            ipe.expect.msg_name, ipe.expect.window[0], ipe.expect.window[1], status
+                            "Expect: {} [{} - {} ms] - {}",
+                            ipe.expect.msg_name,
+                            ipe.expect.window[0],
+                            ipe.expect.window[1],
+                            ipe.result.as_str()
                         ));
-                        for (sig_name, sig_window) in &ipe.expect.signals {
+                        for (sig_name, sig_range) in &ipe.expect.signals {
                             ui.label(format!(
-                                "  Signal: {} [{} - {}]",
-                                sig_name, sig_window[0], sig_window[1]
+                                "  Signal: {} [{} - {} value]",
+                                sig_name, sig_range[0], sig_range[1]
                             ));
                         }
                     }

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -128,7 +128,8 @@ impl Hil {
                 preset_info,
                 tests,
             } => {
-                let time_since_start = start_time.elapsed().as_secs_f64();
+                let time_since_start = start_time.elapsed().as_secs_f64() * 1000.0; // ms
+
                 ui.label(format!(
                     "HIL is running... {:.0} ms since start",
                     time_since_start * 1000.0
@@ -136,42 +137,71 @@ impl Hil {
                 ui.separator();
 
                 if let Some(preset) = preset_info {
-                    ui.heading(format!("Preset: {}", preset.name));
-                    ui.label(format!("Tests: {}", preset.tests.join(", ")));
-                    ui.separator();
+                    ui.label(format!(
+                        "Preset: {}  ({} tests)",
+                        preset.name,
+                        preset.tests.len()
+                    ));
                 }
+                ui.separator();
 
                 for test in tests {
-                    ui.heading(&test.name);
-                    ui.label(&test.description);
+                    egui::CollapsingHeader::new(&test.name)
+                        .id_salt(&test.name)
+                        .default_open(true)
+                        .show(ui, |ui| {
+                            ui.label(&test.description);
 
-                    ui.label(format!(
-                        "TX Remaining: {} messages",
-                        test.tx_remaining.len()
-                    ));
+                            let (not_in_window, in_progress, completed) = test.expect_counts();
+                            let total = not_in_window + in_progress + completed;
+                            if total > 0 {
+                                let frac = completed as f32 / total as f32;
+                                ui.add(
+                                    egui::ProgressBar::new(frac)
+                                        .text(format!("{}/{} expects complete", completed, total)),
+                                );
+                            }
+                            ui.label(format!("TX remaining: {}", test.tx_remaining.len()));
 
-                    let (not_in_window, in_progress, completed) = test.expect_counts();
-                    ui.label(format!(
-                        "Expects: {}/{}/{}",
-                        not_in_window, in_progress, completed
-                    ));
+                            ui.add_space(4.0);
+                            egui::Grid::new(format!("expects_{}", test.name))
+                                .num_columns(4)
+                                .striped(true)
+                                .show(ui, |ui| {
+                                    ui.strong("Message");
+                                    ui.strong("Window (ms)");
+                                    ui.strong("Status");
+                                    ui.strong("Signals");
+                                    ui.end_row();
 
-                    for ipe in &test.in_progress_expects {
-                        ui.label(format!(
-                            "Expect: {} [{} - {} ms] - {}",
-                            ipe.expect.msg_name,
-                            ipe.expect.window[0],
-                            ipe.expect.window[1],
-                            ipe.result.as_str()
-                        ));
-                        for (sig_name, sig_range) in &ipe.expect.signals {
-                            ui.label(format!(
-                                "  Signal: {} [{} - {} value]",
-                                sig_name, sig_range[0], sig_range[1]
-                            ));
-                        }
-                    }
+                                    for ipe in &test.in_progress_expects {
+                                        ui.label(&ipe.expect.msg_name);
+                                        ui.label(format!(
+                                            "{:.0} - {:.0}",
+                                            ipe.expect.window[0], ipe.expect.window[1]
+                                        ));
 
+                                        let color = ipe.result.as_color32();
+                                        let text = ipe.result.as_str();
+                                        ui.colored_label(color, text);
+
+                                        if ipe.expect.signals.is_empty() {
+                                            ui.label("—");
+                                        } else {
+                                            let s: Vec<String> = ipe
+                                                .expect
+                                                .signals
+                                                .iter()
+                                                .map(|(n, r)| {
+                                                    format!("{}: [{}, {}]", n, r[0], r[1])
+                                                })
+                                                .collect();
+                                            ui.label(s.join(", "));
+                                        }
+                                        ui.end_row();
+                                    }
+                                });
+                        });
                     ui.separator();
                 }
             }

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -6,6 +6,7 @@ pub struct Hil {
     pub found_presets: Vec<hil::config::PresetInfo>,
     pub found_tests: Vec<hil::config::TestInfo>,
     pub load_errors: Vec<String>,
+    pub start_error: Option<String>,
     pub hil_state: hil::run::HilState,
 }
 
@@ -18,6 +19,7 @@ impl Hil {
             found_presets: presets,
             found_tests: tests,
             load_errors: errors,
+            start_error: None,
             hil_state: hil::run::HilState::Idle,
         }
     }
@@ -31,10 +33,29 @@ impl Hil {
         self.load_errors = errors;
     }
 
+    fn try_start_from_test(&mut self, test: &hil::config::TestInfo) {
+        let test = match hil::run::HilRunningTest::new(test) {
+            Ok(test) => test,
+            Err(err) => {
+                self.start_error = Some(format!("Error starting test: {}", err));
+                return;
+            }
+        };
+
+        self.hil_state = hil::run::HilState::Running {
+            start_time: std::time::Instant::now(),
+            preset_name: None,
+            tests: vec![test],
+        };
+    }
+
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
         egui::ScrollArea::vertical().show(ui, |ui| match &mut self.hil_state {
             hil::run::HilState::Idle => {
                 ui.label("HIL is idle. Select a preset or test to run.");
+                if ui.button("Reload Tests").clicked() {
+                    self.reload_tests();
+                }
                 ui.separator();
                 if !self.load_errors.is_empty() {
                     ui.label("Errors loading tests:");
@@ -46,7 +67,8 @@ impl Hil {
                 if !self.found_presets.is_empty() {
                     ui.label("Presets:");
                     for preset in &self.found_presets {
-                        if ui.button(&preset.name).clicked() {
+                        let preset_info = format!("{} - {}", preset.name, preset.tests.join(", "));
+                        if ui.button(&preset_info).clicked() {
                             self.hil_state = hil::run::HilState::Running {
                                 start_time: std::time::Instant::now(),
                                 preset_name: Some(preset.name.clone()),
@@ -58,21 +80,16 @@ impl Hil {
                 }
                 if !self.found_tests.is_empty() {
                     ui.label("Individual Tests:");
+                    let mut selected_test = None;
                     for test in &self.found_tests {
-                        let test_info = format!("{}: {}", test.name, test.basename);
+                        let test_info =
+                            format!("{} [{}]: {}", test.name, test.basename, test.description);
                         if ui.button(&test_info).clicked() {
-                            self.hil_state = hil::run::HilState::Running {
-                                start_time: std::time::Instant::now(),
-                                preset_name: None,
-                                // tests: vec![hil::run::HilRunningTest {
-                                // 	name: test.name.clone(),
-                                // 	description: test.description.clone(),
-                                // 	tx_remaining: test.tx.clone(),
-                                // 	expect: test.expect.clone(),
-                                // }],
-                                tests: Vec::new(),
-                            };
+                            selected_test = Some(test.clone());
                         }
+                    }
+                    if let Some(test) = selected_test {
+                        self.try_start_from_test(&test);
                     }
                 }
             }

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -24,7 +24,17 @@ impl Hil {
         }
     }
 
-    pub fn handle_can_message(&mut self, msg: &messages::MsgFromCan) {}
+    pub fn handle_can_message(&mut self, msg: &messages::MsgFromCan) {
+        if let messages::MsgFromCan::ParsedMessage(parsed) = msg
+            && let hil::run::HilState::Running {
+                start_time, tests, ..
+            } = &mut self.hil_state
+        {
+            for test in tests {
+                test.process_can(parsed, *start_time);
+            }
+        }
+    }
 
     fn reload_tests(&mut self) {
         let (presets, tests, errors) = hil::config::list_available_tests();
@@ -129,7 +139,6 @@ impl Hil {
                 tests,
             } => {
                 let time_since_start = start_time.elapsed().as_secs_f64() * 1000.0; // ms
-
                 ui.label(format!(
                     "HIL is running... {:.0} ms since start",
                     time_since_start
@@ -216,10 +225,7 @@ impl Hil {
         let total = not_in_window + in_progress + completed;
         if total > 0 {
             let frac = completed as f32 / total as f32;
-            ui.add(
-                egui::ProgressBar::new(frac)
-                    .text(format!("{}/{} expects complete", completed, total)),
-            );
+            ui.add(egui::ProgressBar::new(frac).text(format!("{}/{} complete", completed, total)));
         }
     }
 

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -132,25 +132,62 @@ impl Hil {
 
                 ui.label(format!(
                     "HIL is running... {:.0} ms since start",
-                    time_since_start * 1000.0
+                    time_since_start
                 ));
                 ui.separator();
 
                 if let Some(preset) = preset_info {
                     ui.label(format!(
-                        "Preset: {}  ({} tests)",
+                        "Preset: {} ({} tests)",
                         preset.name,
                         preset.tests.len()
                     ));
+
+                    let finished_tests: Vec<&hil::run::HilRunningTest> =
+                        tests.iter().filter(|t| t.is_finished()).collect();
+
+                    if finished_tests.len() == tests.len() && !tests.is_empty() {
+                        let (mut total_passed, mut total_expects) = (0, 0);
+                        let mut subtests_all_passed = 0;
+                        for t in tests.iter() {
+                            let (_, _, completed) = t.expect_counts();
+                            let total = t.in_progress_expects.len();
+                            let passed = t
+                                .in_progress_expects
+                                .iter()
+                                .filter(|e| matches!(e.result, hil::run::ExpectResult::Passed))
+                                .count();
+                            total_passed += passed;
+                            total_expects += total;
+                            let _ = completed;
+                            if passed == total {
+                                subtests_all_passed += 1;
+                            }
+                        }
+
+                        let color = if total_passed == total_expects {
+                            egui::Color32::GREEN
+                        } else {
+                            egui::Color32::RED
+                        };
+
+                        ui.colored_label(
+                            color,
+                            format!(
+                                "Preset finished: {}/{} expects passed, {}/{} subtests fully passed",
+                                total_passed, total_expects, subtests_all_passed, tests.len()
+                            ),
+                        );
+                    }
                 }
                 ui.separator();
 
                 for test in tests {
-                    egui::CollapsingHeader::new(&test.name)
-                        .id_salt(&test.name)
+                    egui::CollapsingHeader::new(&test.test_info.name)
+                        .id_salt(&test.test_info.basename)
                         .default_open(true)
                         .show(ui, |ui| {
-                            ui.label(&test.description);
+                            ui.label(&test.test_info.description);
 
                             let (not_in_window, in_progress, completed) = test.expect_counts();
                             let total = not_in_window + in_progress + completed;
@@ -163,8 +200,29 @@ impl Hil {
                             }
                             ui.label(format!("TX remaining: {}", test.tx_remaining.len()));
 
+                            if test.is_finished() {
+                                let passed = test
+                                    .in_progress_expects
+                                    .iter()
+                                    .filter(|e| matches!(e.result, hil::run::ExpectResult::Passed))
+                                    .count();
+                                let total = test.in_progress_expects.len();
+                                let color = if passed == total {
+                                    egui::Color32::GREEN
+                                } else {
+                                    egui::Color32::RED
+                                };
+                                ui.colored_label(
+                                    color,
+                                    format!(
+                                        "Test finished: {} passed of {} expects",
+                                        passed, total
+                                    ),
+                                );
+                            }
+
                             ui.add_space(4.0);
-                            egui::Grid::new(format!("expects_{}", test.name))
+                            egui::Grid::new(format!("expects_{}", test.test_info.basename))
                                 .num_columns(4)
                                 .striped(true)
                                 .show(ui, |ui| {
@@ -181,9 +239,10 @@ impl Hil {
                                             ipe.expect.window[0], ipe.expect.window[1]
                                         ));
 
-                                        let color = ipe.result.as_color32();
-                                        let text = ipe.result.as_str();
-                                        ui.colored_label(color, text);
+                                        ui.colored_label(
+                                            ipe.result.as_color32(),
+                                            ipe.result.as_str(),
+                                        );
 
                                         if ipe.expect.signals.is_empty() {
                                             ui.label("—");

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -44,6 +44,8 @@ impl Hil {
     }
 
     fn try_start_from_test(&mut self, test: &hil::config::TestInfo) {
+        self.start_error = None;
+
         let test = match hil::run::HilRunningTest::new(test) {
             Ok(test) => test,
             Err(err) => {
@@ -60,6 +62,8 @@ impl Hil {
     }
 
     fn try_start_from_preset(&mut self, preset: &hil::config::PresetInfo) {
+        self.start_error = None;
+
         let mut tests = Vec::new();
         for test_name in &preset.tests {
             let test_info = match self.found_tests.iter().find(|t| t.basename == *test_name) {

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -44,7 +44,7 @@ impl Hil {
 
         self.hil_state = hil::run::HilState::Running {
             start_time: std::time::Instant::now(),
-            preset_name: None,
+            preset_info: None,
             tests: vec![test],
         };
     }
@@ -74,7 +74,7 @@ impl Hil {
 
         self.hil_state = hil::run::HilState::Running {
             start_time: std::time::Instant::now(),
-            preset_name: Some(preset.name.clone()),
+            preset_info: Some(preset.clone()),
             tests,
         };
     }
@@ -123,7 +123,56 @@ impl Hil {
                     }
                 }
             }
-            _ => {}
+            hil::run::HilState::Running {
+                start_time,
+                preset_info,
+                tests,
+            } => {
+                let time_since_start = start_time.elapsed().as_secs_f64();
+                ui.label(format!(
+                    "HIL is running... {:.2} seconds since start",
+                    time_since_start
+                ));
+                ui.separator();
+
+                if let Some(preset) = preset_info {
+                    ui.heading(format!("Preset: {}", preset.name));
+                    ui.label(format!("Tests: {}", preset.tests.join(", ")));
+                    ui.separator();
+                }
+
+                for test in tests {
+                    ui.heading(&test.name);
+                    ui.label(&test.description);
+
+                    ui.label(format!(
+                        "TX Remaining: {} messages",
+                        test.tx_remaining.len()
+                    ));
+
+                    let (not_in_window, in_progress, completed) = test.expect_counts();
+                    ui.label(format!(
+                        "Expects: {}/{}/{}",
+                        not_in_window, in_progress, completed
+                    ));
+
+                    for ipe in &test.in_progress_expects {
+                        let status = ipe.result.as_str();
+                        ui.label(format!(
+                            "Expect: {} [{} - {}] - {}",
+                            ipe.expect.msg_name, ipe.expect.window[0], ipe.expect.window[1], status
+                        ));
+                        for (sig_name, sig_window) in &ipe.expect.signals {
+                            ui.label(format!(
+                                "  Signal: {} [{} - {}]",
+                                sig_name, sig_window[0], sig_window[1]
+                            ));
+                        }
+                    }
+
+                    ui.separator();
+                }
+            }
         });
         egui_tiles::UiResponse::None
     }

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -142,129 +142,147 @@ impl Hil {
                         preset.name,
                         preset.tests.len()
                     ));
-
-                    let finished_tests: Vec<&hil::run::HilRunningTest> =
-                        tests.iter().filter(|t| t.is_finished()).collect();
-
-                    if finished_tests.len() == tests.len() && !tests.is_empty() {
-                        let (mut total_passed, mut total_expects) = (0, 0);
-                        let mut subtests_all_passed = 0;
-                        for t in tests.iter() {
-                            let (_, _, completed) = t.expect_counts();
-                            let total = t.in_progress_expects.len();
-                            let passed = t
-                                .in_progress_expects
-                                .iter()
-                                .filter(|e| matches!(e.result, hil::run::ExpectResult::Passed))
-                                .count();
-                            total_passed += passed;
-                            total_expects += total;
-                            let _ = completed;
-                            if passed == total {
-                                subtests_all_passed += 1;
-                            }
-                        }
-
-                        let color = if total_passed == total_expects {
-                            egui::Color32::GREEN
-                        } else {
-                            egui::Color32::RED
-                        };
-
-                        ui.colored_label(
-                            color,
-                            format!(
-                                "Preset finished: {}/{} expects passed, {}/{} subtests fully passed",
-                                total_passed, total_expects, subtests_all_passed, tests.len()
-                            ),
-                        );
-                    }
+                    Self::show_preset_summary(ui, tests);
                 }
                 ui.separator();
 
                 for test in tests {
-                    egui::CollapsingHeader::new(&test.test_info.name)
-                        .id_salt(&test.test_info.basename)
-                        .default_open(true)
-                        .show(ui, |ui| {
-                            ui.label(&test.test_info.description);
-
-                            let (not_in_window, in_progress, completed) = test.expect_counts();
-                            let total = not_in_window + in_progress + completed;
-                            if total > 0 {
-                                let frac = completed as f32 / total as f32;
-                                ui.add(
-                                    egui::ProgressBar::new(frac)
-                                        .text(format!("{}/{} expects complete", completed, total)),
-                                );
-                            }
-                            ui.label(format!("TX remaining: {}", test.tx_remaining.len()));
-
-                            if test.is_finished() {
-                                let passed = test
-                                    .in_progress_expects
-                                    .iter()
-                                    .filter(|e| matches!(e.result, hil::run::ExpectResult::Passed))
-                                    .count();
-                                let total = test.in_progress_expects.len();
-                                let color = if passed == total {
-                                    egui::Color32::GREEN
-                                } else {
-                                    egui::Color32::RED
-                                };
-                                ui.colored_label(
-                                    color,
-                                    format!(
-                                        "Test finished: {} passed of {} expects",
-                                        passed, total
-                                    ),
-                                );
-                            }
-
-                            ui.add_space(4.0);
-                            egui::Grid::new(format!("expects_{}", test.test_info.basename))
-                                .num_columns(4)
-                                .striped(true)
-                                .show(ui, |ui| {
-                                    ui.strong("Message");
-                                    ui.strong("Window (ms)");
-                                    ui.strong("Status");
-                                    ui.strong("Signals");
-                                    ui.end_row();
-
-                                    for ipe in &test.in_progress_expects {
-                                        ui.label(&ipe.expect.msg_name);
-                                        ui.label(format!(
-                                            "{:.0} - {:.0}",
-                                            ipe.expect.window[0], ipe.expect.window[1]
-                                        ));
-
-                                        ui.colored_label(
-                                            ipe.result.as_color32(),
-                                            ipe.result.as_str(),
-                                        );
-
-                                        if ipe.expect.signals.is_empty() {
-                                            ui.label("—");
-                                        } else {
-                                            let s: Vec<String> = ipe
-                                                .expect
-                                                .signals
-                                                .iter()
-                                                .map(|(n, r)| {
-                                                    format!("{}: [{}, {}]", n, r[0], r[1])
-                                                })
-                                                .collect();
-                                            ui.label(s.join(", "));
-                                        }
-                                        ui.end_row();
-                                    }
-                                });
-                        });
+                    Self::show_test(ui, test);
                     ui.separator();
                 }
             }
         });
         egui_tiles::UiResponse::None
+    }
+
+    fn show_preset_summary(ui: &mut egui::Ui, tests: &[hil::run::HilRunningTest]) {
+        if tests.is_empty() || !tests.iter().all(|t| t.is_finished()) {
+            return;
+        }
+
+        let (mut total_passed, mut total_expects, mut subtests_all_passed) = (0, 0, 0);
+        for t in tests {
+            let total = t.in_progress_expects.len();
+            let passed = t
+                .in_progress_expects
+                .iter()
+                .filter(|e| matches!(e.result, hil::run::ExpectResult::Passed))
+                .count();
+            total_passed += passed;
+            total_expects += total;
+            if passed == total {
+                subtests_all_passed += 1;
+            }
+        }
+
+        let color = if total_passed == total_expects {
+            egui::Color32::GREEN
+        } else {
+            egui::Color32::RED
+        };
+
+        ui.colored_label(
+            color,
+            format!(
+                "Preset finished: {}/{} expects passed, {}/{} subtests fully passed",
+                total_passed,
+                total_expects,
+                subtests_all_passed,
+                tests.len()
+            ),
+        );
+    }
+
+    fn show_test(ui: &mut egui::Ui, test: &hil::run::HilRunningTest) {
+        egui::CollapsingHeader::new(&test.test_info.name)
+            .id_salt(&test.test_info.basename)
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.label(&test.test_info.description);
+
+                Self::show_test_progress(ui, test);
+
+                ui.label(format!("TX remaining: {}", test.tx_remaining.len()));
+
+                Self::show_test_finished_summary(ui, test);
+
+                ui.add_space(4.0);
+                Self::show_expects_grid(ui, test);
+            });
+    }
+
+    fn show_test_progress(ui: &mut egui::Ui, test: &hil::run::HilRunningTest) {
+        let (not_in_window, in_progress, completed) = test.expect_counts();
+        let total = not_in_window + in_progress + completed;
+        if total > 0 {
+            let frac = completed as f32 / total as f32;
+            ui.add(
+                egui::ProgressBar::new(frac)
+                    .text(format!("{}/{} expects complete", completed, total)),
+            );
+        }
+    }
+
+    fn show_test_finished_summary(ui: &mut egui::Ui, test: &hil::run::HilRunningTest) {
+        if !test.is_finished() {
+            return;
+        }
+
+        let total = test.in_progress_expects.len();
+        let passed = test
+            .in_progress_expects
+            .iter()
+            .filter(|e| matches!(e.result, hil::run::ExpectResult::Passed))
+            .count();
+
+        let color = if passed == total {
+            egui::Color32::GREEN
+        } else {
+            egui::Color32::RED
+        };
+
+        ui.colored_label(
+            color,
+            format!("Test finished: {} passed of {} expects", passed, total),
+        );
+    }
+
+    fn show_expects_grid(ui: &mut egui::Ui, test: &hil::run::HilRunningTest) {
+        egui::Grid::new(format!("expects_{}", test.test_info.basename))
+            .num_columns(4)
+            .striped(true)
+            .show(ui, |ui| {
+                ui.strong("Message");
+                ui.strong("Window (ms)");
+                ui.strong("Status");
+                ui.strong("Signals");
+                ui.end_row();
+
+                for ipe in &test.in_progress_expects {
+                    Self::show_expect_row(ui, ipe);
+                }
+            });
+    }
+
+    fn show_expect_row(ui: &mut egui::Ui, ipe: &hil::run::InProgressExpect) {
+        ui.label(&ipe.expect.msg_name);
+        ui.label(format!(
+            "{:.0} - {:.0}",
+            ipe.expect.window[0], ipe.expect.window[1]
+        ));
+        ui.colored_label(ipe.result.as_color32(), ipe.result.as_str());
+
+        if ipe.expect.signals.is_empty() {
+            ui.label("—");
+        } else {
+            let s: Vec<String> = ipe
+                .expect
+                .signals
+                .iter()
+                .map(|(n, r)| format!("{}: [{}, {}]", n, r[0], r[1]))
+                .collect();
+            ui.label(s.join(", "));
+        }
+        ui.end_row();
     }
 }

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -41,6 +41,7 @@ impl Hil {
         self.found_presets = presets;
         self.found_tests = tests;
         self.load_errors = errors;
+        self.start_error = None;
     }
 
     fn try_start_from_test(&mut self, test: &hil::config::TestInfo) {

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -141,7 +141,9 @@ impl Hil {
                 tests,
             } => {
                 // Actually run the test
-                tests.iter_mut().for_each(|t| t.update_expect_statuses(*start_time));
+                tests
+                    .iter_mut()
+                    .for_each(|t| t.update_expect_statuses(*start_time));
                 let all_finished = tests.iter().all(|t| t.is_finished());
 
                 ui.add_space(4.0);
@@ -159,7 +161,10 @@ impl Hil {
                             idle_requestedd = true;
                         }
                         let time_since_start = start_time.elapsed().as_millis();
-                        ui.label(format!("HIL is running... {:.0} ms since start", time_since_start));
+                        ui.label(format!(
+                            "HIL is running... {:.0} ms since start",
+                            time_since_start
+                        ));
                     });
                 }
                 ui.separator();

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -1,0 +1,83 @@
+use crate::{hil, messages, ui};
+use eframe::egui;
+
+pub struct Hil {
+    pub title: String,
+    pub found_presets: Vec<hil::config::PresetInfo>,
+    pub found_tests: Vec<hil::config::TestInfo>,
+    pub load_errors: Vec<String>,
+    pub hil_state: hil::run::HilState,
+}
+
+impl Hil {
+    pub fn new(instance_num: usize) -> Self {
+        let (presets, tests, errors) = hil::config::list_available_tests();
+
+        Self {
+            title: format!("HIL #{}", instance_num),
+            found_presets: presets,
+            found_tests: tests,
+            load_errors: errors,
+            hil_state: hil::run::HilState::Idle,
+        }
+    }
+
+    pub fn handle_can_message(&mut self, msg: &messages::MsgFromCan) {}
+
+    fn reload_tests(&mut self) {
+        let (presets, tests, errors) = hil::config::list_available_tests();
+        self.found_presets = presets;
+        self.found_tests = tests;
+        self.load_errors = errors;
+    }
+
+    pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
+        egui::ScrollArea::vertical().show(ui, |ui| match &mut self.hil_state {
+            hil::run::HilState::Idle => {
+                ui.label("HIL is idle. Select a preset or test to run.");
+                ui.separator();
+                if !self.load_errors.is_empty() {
+                    ui.label("Errors loading tests:");
+                    for err in &self.load_errors {
+                        ui.label(format!("- {}", err));
+                    }
+                    ui.separator();
+                }
+                if !self.found_presets.is_empty() {
+                    ui.label("Presets:");
+                    for preset in &self.found_presets {
+                        if ui.button(&preset.name).clicked() {
+                            self.hil_state = hil::run::HilState::Running {
+                                start_time: std::time::Instant::now(),
+                                preset_name: Some(preset.name.clone()),
+                                tests: Vec::new(),
+                            };
+                        }
+                    }
+                    ui.separator();
+                }
+                if !self.found_tests.is_empty() {
+                    ui.label("Individual Tests:");
+                    for test in &self.found_tests {
+                        let test_info = format!("{}: {}", test.name, test.basename);
+                        if ui.button(&test_info).clicked() {
+                            self.hil_state = hil::run::HilState::Running {
+                                start_time: std::time::Instant::now(),
+                                preset_name: None,
+                                // tests: vec![hil::run::HilRunningTest {
+                                // 	name: test.name.clone(),
+                                // 	description: test.description.clone(),
+                                // 	tx_remaining: test.tx.clone(),
+                                // 	expect: test.expect.clone(),
+                                // }],
+                                tests: Vec::new(),
+                            };
+                        }
+                    }
+                }
+            }
+            _ => {}
+        });
+        egui_tiles::UiResponse::None
+    }
+}

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -90,6 +90,8 @@ impl Hil {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
+        let mut idle_requestedd = false;
+
         egui::ScrollArea::vertical().show(ui, |ui| match &mut self.hil_state {
             hil::run::HilState::Idle => {
                 ui.label("HIL is idle. Select a preset or test to run.");
@@ -138,11 +140,28 @@ impl Hil {
                 preset_info,
                 tests,
             } => {
-                let time_since_start = start_time.elapsed().as_secs_f64() * 1000.0; // ms
-                ui.label(format!(
-                    "HIL is running... {:.0} ms since start",
-                    time_since_start
-                ));
+                // Actually run the test
+                tests.iter_mut().for_each(|t| t.update_expect_statuses(*start_time));
+                let all_finished = tests.iter().all(|t| t.is_finished());
+
+                ui.add_space(4.0);
+                if all_finished {
+                    // ui.label("HIL finished! Review the results below.");
+                    ui.horizontal(|ui| {
+                        if ui.button("Exit").clicked() {
+                            idle_requestedd = true;
+                        }
+                        ui.label("HIL finished! Review the results below.");
+                    });
+                } else {
+                    ui.horizontal(|ui| {
+                        if ui.button("Stop").clicked() {
+                            idle_requestedd = true;
+                        }
+                        let time_since_start = start_time.elapsed().as_millis();
+                        ui.label(format!("HIL is running... {:.0} ms since start", time_since_start));
+                    });
+                }
                 ui.separator();
 
                 if let Some(preset) = preset_info {
@@ -161,6 +180,11 @@ impl Hil {
                 }
             }
         });
+
+        if idle_requestedd {
+            self.hil_state = hil::run::HilState::Idle;
+        }
+
         egui_tiles::UiResponse::None
     }
 

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -49,6 +49,36 @@ impl Hil {
         };
     }
 
+    fn try_start_from_preset(&mut self, preset: &hil::config::PresetInfo) {
+        let mut tests = Vec::new();
+        for test_name in &preset.tests {
+            let test_info = match self.found_tests.iter().find(|t| t.basename == *test_name) {
+                Some(info) => info,
+                None => {
+                    self.start_error = Some(format!(
+                        "Error starting preset: Test '{}' not found",
+                        test_name
+                    ));
+                    return;
+                }
+            };
+            let test = match hil::run::HilRunningTest::new(test_info) {
+                Ok(test) => test,
+                Err(err) => {
+                    self.start_error = Some(format!("Error starting preset: {}", err));
+                    return;
+                }
+            };
+            tests.push(test);
+        }
+
+        self.hil_state = hil::run::HilState::Running {
+            start_time: std::time::Instant::now(),
+            preset_name: Some(preset.name.clone()),
+            tests,
+        };
+    }
+
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
         egui::ScrollArea::vertical().show(ui, |ui| match &mut self.hil_state {
             hil::run::HilState::Idle => {
@@ -66,15 +96,15 @@ impl Hil {
                 }
                 if !self.found_presets.is_empty() {
                     ui.label("Presets:");
+                    let mut selected_preset = None;
                     for preset in &self.found_presets {
                         let preset_info = format!("{} - {}", preset.name, preset.tests.join(", "));
                         if ui.button(&preset_info).clicked() {
-                            self.hil_state = hil::run::HilState::Running {
-                                start_time: std::time::Instant::now(),
-                                preset_name: Some(preset.name.clone()),
-                                tests: Vec::new(),
-                            };
+                            selected_preset = Some(preset.clone());
                         }
+                    }
+                    if let Some(preset) = selected_preset {
+                        self.try_start_from_preset(&preset);
                     }
                     ui.separator();
                 }

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -111,6 +111,12 @@ impl Hil {
                     }
                     ui.separator();
                 }
+
+                if let Some(err) = &self.start_error {
+                    ui.colored_label(egui::Color32::RED, err);
+                    ui.separator();
+                }
+
                 if !self.found_presets.is_empty() {
                     ui.label("Presets:");
                     let mut selected_preset = None;

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -1,4 +1,4 @@
-use crate::{hil, messages, ui};
+use crate::{hil, messages};
 use eframe::egui;
 
 pub struct Hil {

--- a/src/ui/hil.rs
+++ b/src/ui/hil.rs
@@ -95,7 +95,7 @@ impl Hil {
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
-        let mut idle_requestedd = false;
+        let mut idle_requested = false;
 
         egui::ScrollArea::vertical().show(ui, |ui| match &mut self.hil_state {
             hil::run::HilState::Idle => {
@@ -162,14 +162,14 @@ impl Hil {
                     // ui.label("HIL finished! Review the results below.");
                     ui.horizontal(|ui| {
                         if ui.button("Exit").clicked() {
-                            idle_requestedd = true;
+                            idle_requested = true;
                         }
                         ui.label("HIL finished! Review the results below.");
                     });
                 } else {
                     ui.horizontal(|ui| {
                         if ui.button("Stop").clicked() {
-                            idle_requestedd = true;
+                            idle_requested = true;
                         }
                         let time_since_start = start_time.elapsed().as_millis();
                         ui.label(format!(
@@ -197,7 +197,7 @@ impl Hil {
             }
         });
 
-        if idle_requestedd {
+        if idle_requested {
             self.hil_state = hil::run::HilState::Idle;
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod command_palette;
 pub mod dbc_msg_picker;
 pub mod dynamics;
 pub mod gg_plot;
+pub mod hil;
 pub mod jitter;
 pub mod log_parser;
 pub mod scope;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -107,7 +107,9 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
             }
             if ui.button("Add HIL").clicked() {
                 app.action_queue
-                    .push(action::AppAction::SpawnWidget(action::WidgetType::Hil));
+                    .push(action::AppAction::SpawnWidget(
+                        widget_constructor::WidgetConstructor::Hil,
+                ));
             }
 
             ui.separator();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -106,9 +106,8 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                 ));
             }
             if ui.button("Add HIL").clicked() {
-                app.action_queue
-                    .push(action::AppAction::SpawnWidget(
-                        widget_constructor::WidgetConstructor::Hil,
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    widget_constructor::WidgetConstructor::Hil,
                 ));
             }
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -105,6 +105,10 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
                     widget_constructor::WidgetConstructor::Jitter,
                 ));
             }
+            if ui.button("Add HIL").clicked() {
+                app.action_queue
+                    .push(action::AppAction::SpawnWidget(action::WidgetType::Hil));
+            }
 
             ui.separator();
             ui.heading("Connection Settings");

--- a/src/widget_constructor.rs
+++ b/src/widget_constructor.rs
@@ -18,6 +18,7 @@ pub enum WidgetConstructor {
     GgPlot,
     Dynamics,
     Jitter,
+    Hil,
 }
 
 impl std::hash::Hash for WidgetConstructor {
@@ -66,6 +67,7 @@ impl WidgetConstructor {
                 widgets::Widget::Dynamics(ui::dynamics::Dynamics::new(id))
             }
             WidgetConstructor::Jitter => widgets::Widget::Jitter(ui::jitter::Jitter::new(id)),
+            WidgetConstructor::Hil => widgets::Widget::Hil(ui::hil::Hil::new(id)),
         }
     }
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -14,6 +14,7 @@ pub enum Widget {
     GgPlot(ui::gg_plot::GgPlot),
     Dynamics(ui::dynamics::Dynamics),
     Jitter(ui::jitter::Jitter),
+    Hil(ui::hil::Hil),
 }
 
 impl Widget {
@@ -31,6 +32,7 @@ impl Widget {
             Widget::GgPlot(w) => &w.title,
             Widget::Dynamics(w) => &w.title,
             Widget::Jitter(w) => &w.title,
+            Widget::Hil(w) => &w.title,
         }
     }
 
@@ -68,6 +70,7 @@ impl Widget {
             Widget::GgPlot(w) => w.show(ui),
             Widget::Dynamics(w) => w.show(ui),
             Widget::Jitter(w) => w.show(ui, parser),
+            Widget::Hil(w) => w.show(ui),
         }
     }
 
@@ -83,6 +86,7 @@ impl Widget {
             Widget::GgPlot(w) => w.handle_can_message(msg),
             Widget::Dynamics(w) => w.handle_can_message(msg),
             Widget::Jitter(w) => w.handle_can_message(msg),
+            Widget::Hil(w) => w.handle_can_message(msg),
             _ => {}
         }
     }


### PR DESCRIPTION


https://github.com/user-attachments/assets/03e6e087-0daf-42ed-b67c-b07a149e815d


Simple HIL only supporting expecting to receive CAN messages at certain windows and validating the values received. Supports both individual tests and presets which are a collection of individual tests.

### Synatx
`hil_config/presets.json`:
```json
{
	"Preset name": [ "individual_test_basename", "another_test_basename" ],
	"All Heartbeats": [ "heartbeats_crit", "heartbeats_non_crit" ]
}
```

`hil_config/tests/individual_test_basename.json`:
```json
{
	"$schema": "../schema.json",

	"name": "Test name",
	"description": "test description",

	"expect": [
		{
			"window": [0, 10000],
			"msg_name": "abox_version"
		},
		{
			"window": [15, 20],
			"msg_name": "thermistor_telemetry",
			"signals": {
				"temperature": [30.0, 40.0]
			}
		}
	]
}
```
Signals is optional. If not provided, will only check that the message is received within the window. You do no have to specify all signals. If a signal is not listed, then it's value will be ignored, only listed signals will be checked.

`window` is in milliseconds after the test has started.

As currently implemented, the UI thread is in charge of running the tests and checking the received CAN messages, so time precision is only ~16-20ms when running at 60 FPS

### Not (yet) supported
- TX. The schema has been added, but support for having the HIL test send messages is not yet implemented.
- Alternative behaviors:
  - Being able to choose to run subtests in a preset back-to-back instead of always in parallel
  - Being able to choose if the first, last, or any message in a expected window is the CAN message used instead of always the first
 - An independent HIL thread (or built into the CAN thread) for 1-2ms precision instead of being tied to the UI.
