### PR TITLE
Widget wiring cleanup 

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -7,7 +7,7 @@ pub enum AppAction {
     DecreaseScale,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Hash, Eq, PartialEq, Clone)]
 pub enum WidgetType {
     ViewerTable,
     ViewerList,

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,5 +1,7 @@
+use crate::widget_constructor;
+
 pub enum AppAction {
-    SpawnWidget(WidgetType),
+    SpawnWidget(widget_constructor::WidgetConstructor),
     ToggleSidebar,
     ToggleCommandPalette,
     CloseActiveWidget,
@@ -7,40 +9,53 @@ pub enum AppAction {
     DecreaseScale,
 }
 
-#[derive(Hash, Eq, PartialEq, Clone)]
-pub enum WidgetType {
-    ViewerTable,
-    ViewerList,
-    Bootloader,
-    Scope {
-        msg_id: u32,
-        msg_name: String,
-        signal_name: String,
-    },
-    LogParser,
-    SendUi,
-    BusLoad,
-    BatteryVoltage,
-    BatteryTemps,
-    GgPlot,
-    Dynamics,
-    Jitter,
-}
-
 impl AppAction {
-    pub fn cmd_palette_list() -> Vec<(&'static str, WidgetType)> {
+    pub fn cmd_palette_list() -> Vec<(&'static str, widget_constructor::WidgetConstructor)> {
         vec![
-            ("Spawn CAN Table", WidgetType::ViewerTable),
-            ("Spawn CAN List", WidgetType::ViewerList),
-            ("Spawn Bootloader", WidgetType::Bootloader),
-            ("Spawn Log Parser", WidgetType::LogParser),
-            ("Spawn Send UI", WidgetType::SendUi),
-            ("Spawn Bus Load", WidgetType::BusLoad),
-            ("Spawn Battery Voltage", WidgetType::BatteryVoltage),
-            ("Spawn Battery Temps", WidgetType::BatteryTemps),
-            ("Spawn G-G Plot", WidgetType::GgPlot),
-            ("Spawn Dynamics", WidgetType::Dynamics),
-            ("Spawn Jitter", WidgetType::Jitter),
+            (
+                "Spawn CAN Table",
+                widget_constructor::WidgetConstructor::ViewerTable,
+            ),
+            (
+                "Spawn CAN List",
+                widget_constructor::WidgetConstructor::ViewerList,
+            ),
+            (
+                "Spawn Bootloader",
+                widget_constructor::WidgetConstructor::Bootloader,
+            ),
+            (
+                "Spawn Log Parser",
+                widget_constructor::WidgetConstructor::LogParser,
+            ),
+            (
+                "Spawn Send UI",
+                widget_constructor::WidgetConstructor::SendUi,
+            ),
+            (
+                "Spawn Bus Load",
+                widget_constructor::WidgetConstructor::BusLoad,
+            ),
+            (
+                "Spawn Battery Voltage",
+                widget_constructor::WidgetConstructor::BatteryVoltage,
+            ),
+            (
+                "Spawn Battery Temps",
+                widget_constructor::WidgetConstructor::BatteryTemps,
+            ),
+            (
+                "Spawn G-G Plot",
+                widget_constructor::WidgetConstructor::GgPlot,
+            ),
+            (
+                "Spawn Dynamics",
+                widget_constructor::WidgetConstructor::Dynamics,
+            ),
+            (
+                "Spawn Jitter",
+                widget_constructor::WidgetConstructor::Jitter,
+            ),
         ]
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,6 @@
 use crate::{
-    action, connection, formatter, messages, settings, shortcuts, theme, ui, util, widgets,
-    widget_ids,
-    workspace,
+    action, connection, formatter, messages, settings, shortcuts, theme, ui, util, widget_ids,
+    widgets, workspace,
 };
 use eframe::egui;
 
@@ -143,54 +142,7 @@ impl DAQApp {
     pub fn handle_action(&mut self, action: action::AppAction, ctx: &egui::Context) {
         match action {
             action::AppAction::SpawnWidget(widget_type) => {
-                let widget = match &widget_type {
-                    action::WidgetType::ViewerTable => widgets::Widget::ViewerTable(
-                        ui::viewer_table::ViewerTable::new(self.widget_ids.next(widget_type)),
-                    ),
-                    action::WidgetType::ViewerList => widgets::Widget::ViewerList(
-                        ui::viewer_list::ViewerList::new(self.widget_ids.next(widget_type))
-                    ),
-                    action::WidgetType::Bootloader => widgets::Widget::Bootloader(
-                        ui::bootloader::Bootloader::new(self.widget_ids.next(widget_type)),
-                    ),
-                    action::WidgetType::Scope {
-                        msg_id,
-                        msg_name,
-                        signal_name,
-                    } => widgets::Widget::Scope(ui::scope::Scope::new(
-                        self.widget_ids.next(widget_type.clone()),
-                        *msg_id,
-                        msg_name.clone(),
-                        signal_name.clone(),
-                    )),
-                    action::WidgetType::LogParser => widgets::Widget::LogParser(
-                        ui::log_parser::LogParser::new(self.widget_ids.next(widget_type))
-                    ),
-                    action::WidgetType::SendUi => widgets::Widget::SendUi(ui::send::SendUi::new(
-                        self.widget_ids.next(widget_type),
-                        self.ui_to_can_tx.clone(),
-                    )),
-                    action::WidgetType::BusLoad => {
-                        widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.widget_ids.next(widget_type)))
-                    }
-                    action::WidgetType::BatteryVoltage => widgets::Widget::BatteryVoltage(
-                        ui::battery::battery_voltage::BatteryVoltage::new(
-                            self.widget_ids.next(widget_type),
-                        ),
-                    ),
-                    action::WidgetType::BatteryTemps => widgets::Widget::BatteryTemps(
-                        ui::battery::battery_temps::BatteryTemps::new(self.widget_ids.next(widget_type)),
-                    ),
-                    action::WidgetType::GgPlot => {
-                        widgets::Widget::GgPlot(ui::gg_plot::GgPlot::new(self.widget_ids.next(widget_type)))
-                    }
-                    action::WidgetType::Dynamics => widgets::Widget::Dynamics(
-                        ui::dynamics::Dynamics::new(self.widget_ids.next(widget_type)),
-                    ),
-                    action::WidgetType::Jitter => {
-                        widgets::Widget::Jitter(ui::jitter::Jitter::new(self.widget_ids.next(widget_type)))
-                    }
-                };
+                let widget = widget_type.create(&mut self.widget_ids, self.ui_to_can_tx.clone());
                 self.add_widget_to_tree(widget);
             }
             action::AppAction::ToggleSidebar => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::{
     action, connection, formatter, messages, settings, shortcuts, theme, ui, util, widgets,
+    widget_ids,
     workspace,
 };
 use eframe::egui;
@@ -39,18 +40,7 @@ pub struct DAQApp {
     pub is_sidebar_open: bool,
     pub command_palette: ui::command_palette::CommandPalette,
     pub tile_tree: egui_tiles::Tree<widgets::Widget>,
-    pub next_can_viewer_num: usize,
-    pub next_can_list_num: usize,
-    pub next_bootloader_num: usize,
-    pub next_scope_num: usize,
-    pub next_log_parser_num: usize,
-    pub next_send_ui_num: usize,
-    pub next_bus_load_num: usize,
-    pub next_battery_voltage_num: usize,
-    pub next_battery_temps_num: usize,
-    pub next_gg_plot_num: usize,
-    pub next_dynamics_num: usize,
-    pub next_jitter_num: usize,
+    pub widget_ids: widget_ids::WidgetIds,
     pub can_to_ui_rx: std::sync::mpsc::Receiver<messages::MsgFromCan>,
     pub ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
     pub action_queue: Vec<action::AppAction>,
@@ -95,18 +85,7 @@ impl DAQApp {
             is_sidebar_open: true,
             command_palette: ui::command_palette::CommandPalette::new(),
             tile_tree: egui_tiles::Tree::empty("workspace_tree"),
-            next_can_viewer_num: 1,
-            next_can_list_num: 1,
-            next_bootloader_num: 1,
-            next_scope_num: 1,
-            next_log_parser_num: 1,
-            next_send_ui_num: 1,
-            next_bus_load_num: 1,
-            next_battery_voltage_num: 1,
-            next_battery_temps_num: 1,
-            next_gg_plot_num: 1,
-            next_dynamics_num: 1,
-            next_jitter_num: 1,
+            widget_ids: widget_ids::WidgetIds::new(),
             can_to_ui_rx,
             ui_to_can_tx,
             action_queue: Vec::new(),
@@ -166,93 +145,53 @@ impl DAQApp {
             action::AppAction::SpawnWidget(widget_type) => {
                 let widget = match &widget_type {
                     action::WidgetType::ViewerTable => widgets::Widget::ViewerTable(
-                        ui::viewer_table::ViewerTable::new(self.next_can_viewer_num),
+                        ui::viewer_table::ViewerTable::new(self.widget_ids.next(widget_type)),
                     ),
                     action::WidgetType::ViewerList => widgets::Widget::ViewerList(
-                        ui::viewer_list::ViewerList::new(self.next_can_list_num),
+                        ui::viewer_list::ViewerList::new(self.widget_ids.next(widget_type))
                     ),
                     action::WidgetType::Bootloader => widgets::Widget::Bootloader(
-                        ui::bootloader::Bootloader::new(self.next_bootloader_num),
+                        ui::bootloader::Bootloader::new(self.widget_ids.next(widget_type)),
                     ),
                     action::WidgetType::Scope {
                         msg_id,
                         msg_name,
                         signal_name,
                     } => widgets::Widget::Scope(ui::scope::Scope::new(
-                        self.next_scope_num,
+                        self.widget_ids.next(widget_type.clone()),
                         *msg_id,
                         msg_name.clone(),
                         signal_name.clone(),
                     )),
                     action::WidgetType::LogParser => widgets::Widget::LogParser(
-                        ui::log_parser::LogParser::new(self.next_log_parser_num),
+                        ui::log_parser::LogParser::new(self.widget_ids.next(widget_type))
                     ),
                     action::WidgetType::SendUi => widgets::Widget::SendUi(ui::send::SendUi::new(
-                        self.next_send_ui_num,
+                        self.widget_ids.next(widget_type),
                         self.ui_to_can_tx.clone(),
                     )),
                     action::WidgetType::BusLoad => {
-                        widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.next_bus_load_num))
+                        widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(self.widget_ids.next(widget_type)))
                     }
                     action::WidgetType::BatteryVoltage => widgets::Widget::BatteryVoltage(
                         ui::battery::battery_voltage::BatteryVoltage::new(
-                            self.next_battery_voltage_num,
+                            self.widget_ids.next(widget_type),
                         ),
                     ),
                     action::WidgetType::BatteryTemps => widgets::Widget::BatteryTemps(
-                        ui::battery::battery_temps::BatteryTemps::new(self.next_battery_temps_num),
+                        ui::battery::battery_temps::BatteryTemps::new(self.widget_ids.next(widget_type)),
                     ),
                     action::WidgetType::GgPlot => {
-                        widgets::Widget::GgPlot(ui::gg_plot::GgPlot::new(self.next_gg_plot_num))
+                        widgets::Widget::GgPlot(ui::gg_plot::GgPlot::new(self.widget_ids.next(widget_type)))
                     }
                     action::WidgetType::Dynamics => widgets::Widget::Dynamics(
-                        ui::dynamics::Dynamics::new(self.next_dynamics_num),
+                        ui::dynamics::Dynamics::new(self.widget_ids.next(widget_type)),
                     ),
                     action::WidgetType::Jitter => {
-                        widgets::Widget::Jitter(ui::jitter::Jitter::new(self.next_jitter_num))
+                        widgets::Widget::Jitter(ui::jitter::Jitter::new(self.widget_ids.next(widget_type)))
                     }
                 };
                 self.add_widget_to_tree(widget);
-
-                // Increment the appropriate counter
-                match widget_type {
-                    action::WidgetType::ViewerTable => {
-                        self.next_can_viewer_num += 1;
-                    }
-                    action::WidgetType::ViewerList => {
-                        self.next_can_list_num += 1;
-                    }
-                    action::WidgetType::Bootloader => {
-                        self.next_bootloader_num += 1;
-                    }
-                    action::WidgetType::Scope { .. } => {
-                        self.next_scope_num += 1;
-                    }
-                    action::WidgetType::LogParser => {
-                        self.next_log_parser_num += 1;
-                    }
-                    action::WidgetType::SendUi => {
-                        self.next_send_ui_num += 1;
-                    }
-                    action::WidgetType::BusLoad => {
-                        self.next_bus_load_num += 1;
-                    }
-                    action::WidgetType::BatteryVoltage => {
-                        self.next_battery_voltage_num += 1;
-                    }
-                    action::WidgetType::BatteryTemps => {
-                        self.next_battery_temps_num += 1;
-                    }
-                    action::WidgetType::GgPlot => {
-                        self.next_gg_plot_num += 1;
-                    }
-                    action::WidgetType::Dynamics => {
-                        self.next_dynamics_num += 1;
-                    }
-                    action::WidgetType::Jitter => {
-                        self.next_jitter_num += 1;
-                    }
-                }
             }
             action::AppAction::ToggleSidebar => {
                 self.is_sidebar_open = !self.is_sidebar_open;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod ui;
 mod util;
 mod widgets;
 mod workspace;
+mod widget_ids;
 
 fn main() -> eframe::Result<()> {
     env_logger::Builder::from_default_env()

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,10 @@ mod shortcuts;
 mod theme;
 mod ui;
 mod util;
+mod widget_constructor;
+mod widget_ids;
 mod widgets;
 mod workspace;
-mod widget_ids;
 
 fn main() -> eframe::Result<()> {
     env_logger::Builder::from_default_env()

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,4 +1,4 @@
-use crate::{action, app, assets, connection, formatter, messages, util};
+use crate::{action, app, assets, connection, formatter, messages, util, widget_constructor};
 use eframe::egui;
 
 pub fn select_dbc(
@@ -44,61 +44,66 @@ pub fn show(app: &mut app::DAQApp, ctx: &egui::Context) {
 
             if ui.button("Add CAN Viewer Table").clicked() {
                 app.action_queue.push(action::AppAction::SpawnWidget(
-                    action::WidgetType::ViewerTable,
+                    widget_constructor::WidgetConstructor::ViewerTable,
                 ));
             }
 
             if ui.button("Add CAN Viewer List").clicked() {
                 app.action_queue.push(action::AppAction::SpawnWidget(
-                    action::WidgetType::ViewerList,
+                    widget_constructor::WidgetConstructor::ViewerList,
                 ));
             }
 
             if ui.button("Add Bootloader").clicked() {
                 app.action_queue.push(action::AppAction::SpawnWidget(
-                    action::WidgetType::Bootloader,
+                    widget_constructor::WidgetConstructor::Bootloader,
                 ));
             }
 
             if ui.button("Add Log Parser").clicked() {
                 app.action_queue.push(action::AppAction::SpawnWidget(
-                    action::WidgetType::LogParser,
+                    widget_constructor::WidgetConstructor::LogParser,
                 ));
             }
 
             if ui.button("Add Message Sender").clicked() {
-                app.action_queue
-                    .push(action::AppAction::SpawnWidget(action::WidgetType::SendUi));
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    widget_constructor::WidgetConstructor::SendUi,
+                ));
             }
 
             if ui.button("Add Bus Load").clicked() {
-                app.action_queue
-                    .push(action::AppAction::SpawnWidget(action::WidgetType::BusLoad));
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    widget_constructor::WidgetConstructor::BusLoad,
+                ));
             }
 
             if ui.button("Add Battery Voltage").clicked() {
                 app.action_queue.push(action::AppAction::SpawnWidget(
-                    action::WidgetType::BatteryVoltage,
+                    widget_constructor::WidgetConstructor::BatteryVoltage,
                 ));
             }
 
             if ui.button("Add Battery Temps").clicked() {
                 app.action_queue.push(action::AppAction::SpawnWidget(
-                    action::WidgetType::BatteryTemps,
+                    widget_constructor::WidgetConstructor::BatteryTemps,
                 ));
             }
 
             if ui.button("Add G-G Plot").clicked() {
-                app.action_queue
-                    .push(action::AppAction::SpawnWidget(action::WidgetType::GgPlot));
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    widget_constructor::WidgetConstructor::GgPlot,
+                ));
             }
             if ui.button("Add Dynamics").clicked() {
-                app.action_queue
-                    .push(action::AppAction::SpawnWidget(action::WidgetType::Dynamics));
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    widget_constructor::WidgetConstructor::Dynamics,
+                ));
             }
             if ui.button("Add Jitter").clicked() {
-                app.action_queue
-                    .push(action::AppAction::SpawnWidget(action::WidgetType::Jitter));
+                app.action_queue.push(action::AppAction::SpawnWidget(
+                    widget_constructor::WidgetConstructor::Jitter,
+                ));
             }
 
             ui.separator();

--- a/src/ui/viewer_table.rs
+++ b/src/ui/viewer_table.rs
@@ -1,4 +1,4 @@
-use crate::{action, app, formatter, frozen, messages};
+use crate::{action, app, formatter, frozen, messages, widget_constructor};
 use eframe::egui;
 
 type DecodedMsgMap = hashbrown::HashMap<u32, messages::ParsedMessage>;
@@ -393,7 +393,7 @@ impl MessageCard<'_> {
                                 |ui| {
                                     if ui.small_button("📊").clicked() {
                                         action_queue.push(action::AppAction::SpawnWidget(
-                                            action::WidgetType::Scope {
+                                            widget_constructor::WidgetConstructor::Scope {
                                                 msg_id: self.msg_id,
                                                 msg_name: self.msg_name.to_string(),
                                                 signal_name: sig_name.to_string(),

--- a/src/widget_constructor.rs
+++ b/src/widget_constructor.rs
@@ -1,6 +1,6 @@
 use crate::{messages, ui, widget_ids, widgets};
 
-#[derive(Hash, Eq, PartialEq, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub enum WidgetConstructor {
     ViewerTable,
     ViewerList,
@@ -18,6 +18,25 @@ pub enum WidgetConstructor {
     GgPlot,
     Dynamics,
     Jitter,
+}
+
+impl std::hash::Hash for WidgetConstructor {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            WidgetConstructor::ViewerTable => 0.hash(state),
+            WidgetConstructor::ViewerList => 1.hash(state),
+            WidgetConstructor::Bootloader => 2.hash(state),
+            WidgetConstructor::Scope { .. } => 3.hash(state),
+            WidgetConstructor::LogParser => 4.hash(state),
+            WidgetConstructor::SendUi => 5.hash(state),
+            WidgetConstructor::BusLoad => 6.hash(state),
+            WidgetConstructor::BatteryVoltage => 7.hash(state),
+            WidgetConstructor::BatteryTemps => 8.hash(state),
+            WidgetConstructor::GgPlot => 9.hash(state),
+            WidgetConstructor::Dynamics => 10.hash(state),
+            WidgetConstructor::Jitter => 11.hash(state),
+        }
+    }
 }
 
 impl WidgetConstructor {

--- a/src/widget_constructor.rs
+++ b/src/widget_constructor.rs
@@ -22,20 +22,7 @@ pub enum WidgetConstructor {
 
 impl std::hash::Hash for WidgetConstructor {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            WidgetConstructor::ViewerTable => 0.hash(state),
-            WidgetConstructor::ViewerList => 1.hash(state),
-            WidgetConstructor::Bootloader => 2.hash(state),
-            WidgetConstructor::Scope { .. } => 3.hash(state),
-            WidgetConstructor::LogParser => 4.hash(state),
-            WidgetConstructor::SendUi => 5.hash(state),
-            WidgetConstructor::BusLoad => 6.hash(state),
-            WidgetConstructor::BatteryVoltage => 7.hash(state),
-            WidgetConstructor::BatteryTemps => 8.hash(state),
-            WidgetConstructor::GgPlot => 9.hash(state),
-            WidgetConstructor::Dynamics => 10.hash(state),
-            WidgetConstructor::Jitter => 11.hash(state),
-        }
+        std::mem::discriminant(self).hash(state);
     }
 }
 

--- a/src/widget_constructor.rs
+++ b/src/widget_constructor.rs
@@ -1,0 +1,65 @@
+use crate::{messages, ui, widget_ids, widgets};
+
+#[derive(Hash, Eq, PartialEq, Clone)]
+pub enum WidgetConstructor {
+    ViewerTable,
+    ViewerList,
+    Bootloader,
+    Scope {
+        msg_id: u32,
+        msg_name: String,
+        signal_name: String,
+    },
+    LogParser,
+    SendUi,
+    BusLoad,
+    BatteryVoltage,
+    BatteryTemps,
+    GgPlot,
+    Dynamics,
+    Jitter,
+}
+
+impl WidgetConstructor {
+    pub fn create(
+        self,
+        widget_ids: &mut widget_ids::WidgetIds,
+        ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
+    ) -> widgets::Widget {
+        let id = widget_ids.next(self.clone());
+        match self {
+            WidgetConstructor::ViewerTable => {
+                widgets::Widget::ViewerTable(ui::viewer_table::ViewerTable::new(id))
+            }
+            WidgetConstructor::ViewerList => {
+                widgets::Widget::ViewerList(ui::viewer_list::ViewerList::new(id))
+            }
+            WidgetConstructor::Bootloader => {
+                widgets::Widget::Bootloader(ui::bootloader::Bootloader::new(id))
+            }
+            WidgetConstructor::Scope {
+                msg_id,
+                msg_name,
+                signal_name,
+            } => widgets::Widget::Scope(ui::scope::Scope::new(id, msg_id, msg_name, signal_name)),
+            WidgetConstructor::LogParser => {
+                widgets::Widget::LogParser(ui::log_parser::LogParser::new(id))
+            }
+            WidgetConstructor::SendUi => {
+                widgets::Widget::SendUi(ui::send::SendUi::new(id, ui_to_can_tx))
+            }
+            WidgetConstructor::BusLoad => widgets::Widget::BusLoad(ui::bus_load::BusLoad::new(id)),
+            WidgetConstructor::BatteryVoltage => widgets::Widget::BatteryVoltage(
+                ui::battery::battery_voltage::BatteryVoltage::new(id),
+            ),
+            WidgetConstructor::BatteryTemps => {
+                widgets::Widget::BatteryTemps(ui::battery::battery_temps::BatteryTemps::new(id))
+            }
+            WidgetConstructor::GgPlot => widgets::Widget::GgPlot(ui::gg_plot::GgPlot::new(id)),
+            WidgetConstructor::Dynamics => {
+                widgets::Widget::Dynamics(ui::dynamics::Dynamics::new(id))
+            }
+            WidgetConstructor::Jitter => widgets::Widget::Jitter(ui::jitter::Jitter::new(id)),
+        }
+    }
+}

--- a/src/widget_ids.rs
+++ b/src/widget_ids.rs
@@ -1,0 +1,20 @@
+use crate::action;
+
+pub struct WidgetIds {
+    counters: std::collections::HashMap<action::WidgetType, usize>,
+}
+
+impl WidgetIds {
+	pub fn new() -> Self {
+		Self {
+			counters: std::collections::HashMap::new(),
+		}
+	}
+
+    pub fn next(&mut self, kind: action::WidgetType) -> usize {
+        let counter = self.counters.entry(kind).or_insert(1);
+        let id = *counter;
+        *counter += 1;
+        id
+    }
+}

--- a/src/widget_ids.rs
+++ b/src/widget_ids.rs
@@ -1,17 +1,17 @@
-use crate::action;
+use crate::widget_constructor;
 
 pub struct WidgetIds {
-    counters: std::collections::HashMap<action::WidgetType, usize>,
+    counters: std::collections::HashMap<widget_constructor::WidgetConstructor, usize>,
 }
 
 impl WidgetIds {
-	pub fn new() -> Self {
-		Self {
-			counters: std::collections::HashMap::new(),
-		}
-	}
+    pub fn new() -> Self {
+        Self {
+            counters: std::collections::HashMap::new(),
+        }
+    }
 
-    pub fn next(&mut self, kind: action::WidgetType) -> usize {
+    pub fn next(&mut self, kind: widget_constructor::WidgetConstructor) -> usize {
         let counter = self.counters.entry(kind).or_insert(1);
         let id = *counter;
         *counter += 1;

--- a/src/widget_ids.rs
+++ b/src/widget_ids.rs
@@ -1,7 +1,10 @@
 use crate::widget_constructor;
 
 pub struct WidgetIds {
-    counters: std::collections::HashMap<widget_constructor::WidgetConstructor, usize>,
+    counters: std::collections::HashMap<
+        std::mem::Discriminant<widget_constructor::WidgetConstructor>,
+        usize,
+    >,
 }
 
 impl WidgetIds {
@@ -12,7 +15,8 @@ impl WidgetIds {
     }
 
     pub fn next(&mut self, kind: widget_constructor::WidgetConstructor) -> usize {
-        let counter = self.counters.entry(kind).or_insert(1);
+        let disc = std::mem::discriminant(&kind);
+        let counter = self.counters.entry(disc).or_insert(1);
         let id = *counter;
         *counter += 1;
         id


### PR DESCRIPTION
- Convert WidgetType to a full Widget Constructor
- Introduce WidgetIds to automatically assign the widget number (removes all `next_`widget_name`_num`)