### PR TITLE
Add 1 point timestamp fallback during wall clock correlation

### DIFF
--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -224,7 +224,7 @@ struct Point {
 
 /// Least squares linear regression.
 ///
-/// Note: on if there is only 1 point, uses REGRESSION_FALLBACK_SLOPE
+/// Note: if there is only 1 point, uses REGRESSION_FALLBACK_SLOPE
 ///
 /// Fits:
 /// y = slope * x + intercept

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -169,7 +169,10 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
     let (slope, intercept) = match linear_regression(&points) {
         Some(v) => v,
         None => {
-            log::error!("Failed to refit correlation line. Points: {:?}", points);
+            log::error!(
+                "Failed to refit correlation line. Points count: {}",
+                points.len()
+            );
             return CorrelationChunkResult::uncorrelated_new(chunk);
         }
     };
@@ -210,7 +213,6 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
     )
 }
 
-#[derive(Debug)]
 struct Point {
     x: f64, // log timestamp ms
     y: f64, // unix timestamp ms

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -3,10 +3,9 @@ use chrono::TimeZone as _;
 
 use crate::daq_log_parse::parse::ParsedMessage;
 
-// If there is only one GPS point, it is not possible to do a linear regression.
-// In that case, we will use this fallback slope value. It is in general safe to
-// assume a slope of 1.0, since DAQ runs at 1 tick = 1 ms, but in post processing,
-// there is not a reason to not run proper linear regression if there are multiple GPS points.
+// In that case we use this fallback slope value. It is generally safe to assume a
+// slope of 1.0 since the DAQ runs at 1 tick = 1 ms, but in post-processing there
+// is no reason not to run a proper linear regression when multiple GPS points exist.
 const REGRESSION_FALLBACK_SLOPE: f64 = 1.0;
 
 pub struct CorrelationFunction {

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -197,6 +197,11 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         points.len()
     );
 
+    // Log error (but continue) if slope is not ~1.0
+    if (slope - 1.0).abs() > 0.001 {
+        log::error!("GPS correlation slope is not ~1.0");
+    }
+
     CorrelationChunkResult::correlated_new(
         chunk,
         CorrelationFunction {

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -230,6 +230,7 @@ fn linear_regression(points: &[Point]) -> Option<(f64, f64)> {
 
     // Fallback for single point: use a default slope and calculate intercept based on that point
     if points.len() == 1 {
+        log::warn!("Only one GPS point found, using fallback slope of {}", REGRESSION_FALLBACK_SLOPE);
         let p = &points[0];
         let slope = REGRESSION_FALLBACK_SLOPE;
         let intercept = p.y - slope * p.x;

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -230,7 +230,10 @@ fn linear_regression(points: &[Point]) -> Option<(f64, f64)> {
 
     // Fallback for single point: use a default slope and calculate intercept based on that point
     if points.len() == 1 {
-        log::warn!("Only one GPS point found, using fallback slope of {}", REGRESSION_FALLBACK_SLOPE);
+        log::warn!(
+            "Only one GPS point found, using fallback slope of {}",
+            REGRESSION_FALLBACK_SLOPE
+        );
         let p = &points[0];
         let slope = REGRESSION_FALLBACK_SLOPE;
         let intercept = p.y - slope * p.x;

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -199,9 +199,13 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
         points.len()
     );
 
-    // Log error (but continue) if slope is not ~1.0
-    if (slope - 1.0).abs() > 0.001 {
-        log::error!("GPS correlation slope is not ~1.0");
+    // Log error (but continue) if slope is not ~REGRESSION_FALLBACK_SLOPE
+    if (slope - REGRESSION_FALLBACK_SLOPE).abs() > 0.001 {
+        log::error!(
+            "GPS correlation slope ({:.9}) deviates from expected {:.3}.",
+            slope,
+            REGRESSION_FALLBACK_SLOPE,
+        );
     }
 
     CorrelationChunkResult::correlated_new(

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -155,6 +155,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
 
     if gps_points.is_empty() {
         // No GPS points found, can't correlate
+        log::warn!("No GPS points found in chunk, cannot correlate timestamps");
         return CorrelationChunkResult::uncorrelated_new(chunk);
     }
 
@@ -169,7 +170,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
     let (slope, intercept) = match linear_regression(&points) {
         Some(v) => v,
         None => {
-            log::error!("Failed to refit correlation line");
+            log::error!("Failed to refit correlation line. Points: {:?}", points);
             return CorrelationChunkResult::uncorrelated_new(chunk);
         }
     };
@@ -205,6 +206,7 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
     )
 }
 
+#[derive(Debug)]
 struct Point {
     x: f64, // log timestamp ms
     y: f64, // unix timestamp ms

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -3,6 +3,12 @@ use chrono::TimeZone as _;
 
 use crate::daq_log_parse::parse::ParsedMessage;
 
+// If there is only one GPS point, it is not possible to do a linear regression.
+// In that case, we will use this fallback slope value. It is in general safe to
+// assume a slope of 1.0, since DAQ runs at 1 tick = 1 ms, but in post processing,
+// there is not a reason to not run proper linear regression if there are multiple GPS points.
+const REGRESSION_FALLBACK_SLOPE: f64 = 1.0;
+
 pub struct CorrelationFunction {
     /// real_time ~= slope * log_time_ms + intercept_ms
     ///
@@ -206,12 +212,21 @@ struct Point {
 
 /// Least squares linear regression.
 ///
-/// Fits:
+/// Note: on if there is only 1 point, uses REGRESSION_FALLBACK_SLOPE
 ///
+/// Fits:
 /// y = slope * x + intercept
 fn linear_regression(points: &[Point]) -> Option<(f64, f64)> {
-    if points.len() < 2 {
+    if points.is_empty() {
         return None;
+    }
+
+    // Fallback for single point: use a default slope and calculate intercept based on that point
+    if points.len() == 1 {
+        let p = &points[0];
+        let slope = REGRESSION_FALLBACK_SLOPE;
+        let intercept = p.y - slope * p.x;
+        return Some((slope, intercept));
     }
 
     let n = points.len() as f64;


### PR DESCRIPTION
In general, our linear regression system of correlating DAQ ticks to wall clock time is a little overkill and not required. DAQ *should* always (just like every other PER board) run at 1 tick = 1 ms. However, when we have the information, there is no downside to doing this correlation.

But, on the chances that there are chunks with only 1 GPS timestamp, it is acceptable to assume the time correlation of 1 tick = 1 ms.