### PR TITLE
Time correlation and CSV output use UTC and RFC 3339

### DIFF
--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -20,7 +20,17 @@ pub struct CorrelationFunction {
 impl CorrelationFunction {
     pub fn correlate(&self, log_ts: u32) -> Option<chrono::DateTime<chrono::Utc>> {
         let unix_ms = self.slope * log_ts as f64 + self.intercept_ms;
-        chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64)
+        match chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64) {
+            Some(dt) => Some(dt),
+            None => {
+                log::error!(
+                    "Correlated time {} ms for log time {} ms is out of range for chrono::DateTime",
+                    unix_ms,
+                    log_ts
+                );
+                None
+            }
+        }
     }
 }
 

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -18,20 +18,9 @@ pub struct CorrelationFunction {
 }
 
 impl CorrelationFunction {
-    pub fn correlate(&self, log_ts: u32) -> Option<chrono::DateTime<chrono::Local>> {
+    pub fn correlate(&self, log_ts: u32) -> Option<chrono::DateTime<chrono::Utc>> {
         let unix_ms = self.slope * log_ts as f64 + self.intercept_ms;
-
-        match chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64) {
-            Some(dt) => Some(dt.with_timezone(&chrono::Local)),
-            None => {
-                log::error!(
-                    "Correlated time {} ms for log time {} ms is out of range for chrono::DateTime",
-                    unix_ms,
-                    log_ts
-                );
-                None
-            }
-        }
+        chrono::DateTime::from_timestamp_millis(unix_ms.round() as i64)
     }
 }
 

--- a/src/daq_log_parse/correlate.rs
+++ b/src/daq_log_parse/correlate.rs
@@ -111,19 +111,18 @@ pub fn time_correlate_chunk(chunk: Vec<ParsedMessage>) -> CorrelationChunkResult
                     })
                 {
                     let dt_utc = chrono::Utc.from_utc_datetime(&dt);
-                    let dt_local = chrono::DateTime::<chrono::Local>::from(dt_utc);
 
-                    let current_year = chrono::Local::now().year();
-                    if dt_local.year() < current_year - 2 || dt_local.year() > current_year + 2 {
+                    let current_year = chrono::Utc::now().year();
+                    if dt_utc.year() < current_year - 2 || dt_utc.year() > current_year + 2 {
                         log::warn!(
                             "GPS message at {} ms has suspicious year value {}, skipping",
                             msg.timestamp,
-                            dt_local.year()
+                            dt_utc.year()
                         );
                         continue;
                     }
 
-                    gps_points.push((msg.timestamp, dt_local));
+                    gps_points.push((msg.timestamp, dt_utc));
                 } else {
                     log::error!(
                         "GPS message at {} ms has invalid date/time values, skipping",

--- a/src/daq_log_parse/table.rs
+++ b/src/daq_log_parse/table.rs
@@ -157,8 +157,10 @@ impl TableBuilder {
 
             let first_correlated_time: Option<String> =
                 chunk.correlation_fn.as_ref().and_then(|cf| {
-                    cf.correlate(first_time)
-                        .map(|dt| dt.format("%Y_%m_%d__%H_%M_%S").to_string())
+                    cf.correlate(first_time).map(|dt| {
+                        dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+                            .replace(':', "-")
+                    })
                 });
 
             let out_file = match first_correlated_time {
@@ -181,7 +183,7 @@ impl TableBuilder {
                     .as_ref()
                     .and_then(|cf| cf.correlate(row_time))
                 {
-                    row[0] = ct.format("%H:%M:%S.%3f").to_string();
+                    row[0] = ct.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
                 }
                 row[1] = format!("{:.3}", row_time as f32 / 1000.0);
 


### PR DESCRIPTION
* Note: RFC 3339 is "internet-friendly" profile of ISO 8601
* Time correlation: previously converted GPS times (which are in UTC) to Local and then converted to unix timestamps which is potentially error prone and not our intended final output
* Output (CSV real time row): now outputs in RFC 3339 instead of a random format I hand made,
* Output (filenaming): Uses RFC 3339 but has the `:` replaced with `-` to be safe for use in a file name